### PR TITLE
Fix Drawing bugs

### DIFF
--- a/app/src/androidMain/res/xml/provider_path.xml
+++ b/app/src/androidMain/res/xml/provider_path.xml
@@ -18,4 +18,5 @@
     <files-path
         name="external_files"
         path="." />
+    <cache-path name="shared_images" path="images/"/>
 </paths>

--- a/core/data/src/nonJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
+++ b/core/data/src/nonJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
@@ -328,4 +328,4 @@ fun NotificationEntity.asModel(): Notification {
     )
 }
 
-fun Long.check() = if (this == -1L) null else this
+fun Long.check() = if (this >0) this else null

--- a/core/data/src/nonJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
+++ b/core/data/src/nonJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
@@ -328,4 +328,4 @@ fun NotificationEntity.asModel(): Notification {
     )
 }
 
-fun Long.check() = if (this >0) this else null
+fun Long.check() = if (this > 0) this else null

--- a/core/data/src/wasmJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
+++ b/core/data/src/wasmJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
@@ -330,4 +330,4 @@ fun NotificationEntity.asModel(): Notification {
     )
 }
 
-fun Long.check() = if (this >0) this else null
+fun Long.check() = if (this > 0) this else null

--- a/core/data/src/wasmJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
+++ b/core/data/src/wasmJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
@@ -330,4 +330,4 @@ fun NotificationEntity.asModel(): Notification {
     )
 }
 
-fun Long.check() = if (this == -1L) null else this
+fun Long.check() = if (this >0) this else null

--- a/core/data/src/wasmJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
+++ b/core/data/src/wasmJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
@@ -111,7 +111,7 @@ fun NotePad.asEntity() = NoteEntity(
     noteType = noteCategory.ordinal,
 )
 
-fun NoteImage.asEntity() = NoteImageEntity(id.check(), noteId, path)
+fun NoteImage.asEntity() = NoteImageEntity(  id = id, noteId, path)
 fun NoteImageEntity.asModel() =
     NoteImage(id = id, noteId = noteId)
 
@@ -119,7 +119,7 @@ fun NoteLabelCrossRef.asModel() = com.mshdabiola.model.note.NoteLabelCrossRef(no
 fun com.mshdabiola.model.note.NoteLabelCrossRef.asEntity() = NoteLabelCrossRef(noteId = noteId, labelId = labelId)
 
 fun NoteVoice.asEntity() = NoteVoiceEntity(
-    id = id.check(),
+    id = id,
     noteId = noteId,
     path = path,
 )

--- a/core/data/src/wasmJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
+++ b/core/data/src/wasmJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
@@ -111,7 +111,7 @@ fun NotePad.asEntity() = NoteEntity(
     noteType = noteCategory.ordinal,
 )
 
-fun NoteImage.asEntity() = NoteImageEntity(id, noteId, path)
+fun NoteImage.asEntity() = NoteImageEntity(id.check(), noteId, path)
 fun NoteImageEntity.asModel() =
     NoteImage(id = id, noteId = noteId)
 
@@ -119,7 +119,7 @@ fun NoteLabelCrossRef.asModel() = com.mshdabiola.model.note.NoteLabelCrossRef(no
 fun com.mshdabiola.model.note.NoteLabelCrossRef.asEntity() = NoteLabelCrossRef(noteId = noteId, labelId = labelId)
 
 fun NoteVoice.asEntity() = NoteVoiceEntity(
-    id = id,
+    id = id.check(),
     noteId = noteId,
     path = path,
 )

--- a/core/data/src/wasmJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
+++ b/core/data/src/wasmJsMain/kotlin/com/mshdabiola/data/model/DataExtension.kt
@@ -111,7 +111,7 @@ fun NotePad.asEntity() = NoteEntity(
     noteType = noteCategory.ordinal,
 )
 
-fun NoteImage.asEntity() = NoteImageEntity(  id = id, noteId, path)
+fun NoteImage.asEntity() = NoteImageEntity(id = id, noteId, path)
 fun NoteImageEntity.asModel() =
     NoteImage(id = id, noteId = noteId)
 

--- a/core/designsystem/src/commonMain/kotlin/com/mshdabiola/designsystem/drawable/SynDrawable.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/mshdabiola/designsystem/drawable/SynDrawable.kt
@@ -550,9 +550,6 @@ val AppIcon: ImageVector
 @Suppress("ObjectPropertyName")
 private var _AppIcon: ImageVector? = null
 
-
-
-
 val Redo: ImageVector
     get() {
         if (_Redo != null) return _Redo!!
@@ -562,10 +559,10 @@ val Redo: ImageVector
             defaultWidth = 24.dp,
             defaultHeight = 24.dp,
             viewportWidth = 960f,
-            viewportHeight = 960f
+            viewportHeight = 960f,
         ).apply {
             path(
-                fill = SolidColor(Color(0xFF000000))
+                fill = SolidColor(Color(0xFF000000)),
             ) {
                 moveTo(396f, 760f)
                 quadToRelative(-97f, 0f, -166.5f, -63f)
@@ -593,8 +590,8 @@ val Redo: ImageVector
         return _Redo!!
     }
 
+@Suppress("ObjectPropertyName")
 private var _Redo: ImageVector? = null
-
 
 val Undo: ImageVector
     get() {
@@ -605,10 +602,10 @@ val Undo: ImageVector
             defaultWidth = 24.dp,
             defaultHeight = 24.dp,
             viewportWidth = 960f,
-            viewportHeight = 960f
+            viewportHeight = 960f,
         ).apply {
             path(
-                fill = SolidColor(Color(0xFF000000))
+                fill = SolidColor(Color(0xFF000000)),
             ) {
                 moveTo(280f, 760f)
                 verticalLineToRelative(-80f)
@@ -636,7 +633,5 @@ val Undo: ImageVector
         return _Undo!!
     }
 
+@Suppress("ObjectPropertyName")
 private var _Undo: ImageVector? = null
-
-
-

--- a/core/designsystem/src/commonMain/kotlin/com/mshdabiola/designsystem/drawable/SynDrawable.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/mshdabiola/designsystem/drawable/SynDrawable.kt
@@ -560,7 +560,7 @@ val Redo: ImageVector
             defaultHeight = 24.dp,
             viewportWidth = 960f,
             viewportHeight = 960f,
-            autoMirror = true
+            autoMirror = true,
         ).apply {
             path(
                 fill = SolidColor(Color(0xFF000000)),
@@ -604,7 +604,7 @@ val Undo: ImageVector
             defaultHeight = 24.dp,
             viewportWidth = 960f,
             viewportHeight = 960f,
-            autoMirror = true
+            autoMirror = true,
         ).apply {
             path(
                 fill = SolidColor(Color(0xFF000000)),

--- a/core/designsystem/src/commonMain/kotlin/com/mshdabiola/designsystem/drawable/SynDrawable.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/mshdabiola/designsystem/drawable/SynDrawable.kt
@@ -560,6 +560,7 @@ val Redo: ImageVector
             defaultHeight = 24.dp,
             viewportWidth = 960f,
             viewportHeight = 960f,
+            autoMirror = true
         ).apply {
             path(
                 fill = SolidColor(Color(0xFF000000)),
@@ -603,6 +604,7 @@ val Undo: ImageVector
             defaultHeight = 24.dp,
             viewportWidth = 960f,
             viewportHeight = 960f,
+            autoMirror = true
         ).apply {
             path(
                 fill = SolidColor(Color(0xFF000000)),

--- a/core/designsystem/src/commonMain/kotlin/com/mshdabiola/designsystem/drawable/SynDrawable.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/mshdabiola/designsystem/drawable/SynDrawable.kt
@@ -549,3 +549,94 @@ val AppIcon: ImageVector
 
 @Suppress("ObjectPropertyName")
 private var _AppIcon: ImageVector? = null
+
+
+
+
+val Redo: ImageVector
+    get() {
+        if (_Redo != null) return _Redo!!
+
+        _Redo = ImageVector.Builder(
+            name = "Redo",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 960f,
+            viewportHeight = 960f
+        ).apply {
+            path(
+                fill = SolidColor(Color(0xFF000000))
+            ) {
+                moveTo(396f, 760f)
+                quadToRelative(-97f, 0f, -166.5f, -63f)
+                reflectiveQuadTo(160f, 540f)
+                reflectiveQuadToRelative(69.5f, -157f)
+                reflectiveQuadTo(396f, 320f)
+                horizontalLineToRelative(252f)
+                lineTo(544f, 216f)
+                lineToRelative(56f, -56f)
+                lineToRelative(200f, 200f)
+                lineToRelative(-200f, 200f)
+                lineToRelative(-56f, -56f)
+                lineToRelative(104f, -104f)
+                horizontalLineTo(396f)
+                quadToRelative(-63f, 0f, -109.5f, 40f)
+                reflectiveQuadTo(240f, 540f)
+                reflectiveQuadToRelative(46.5f, 100f)
+                reflectiveQuadTo(396f, 680f)
+                horizontalLineToRelative(284f)
+                verticalLineToRelative(80f)
+                close()
+            }
+        }.build()
+
+        return _Redo!!
+    }
+
+private var _Redo: ImageVector? = null
+
+
+val Undo: ImageVector
+    get() {
+        if (_Undo != null) return _Undo!!
+
+        _Undo = ImageVector.Builder(
+            name = "Undo",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 960f,
+            viewportHeight = 960f
+        ).apply {
+            path(
+                fill = SolidColor(Color(0xFF000000))
+            ) {
+                moveTo(280f, 760f)
+                verticalLineToRelative(-80f)
+                horizontalLineToRelative(284f)
+                quadToRelative(63f, 0f, 109.5f, -40f)
+                reflectiveQuadTo(720f, 540f)
+                reflectiveQuadToRelative(-46.5f, -100f)
+                reflectiveQuadTo(564f, 400f)
+                horizontalLineTo(312f)
+                lineToRelative(104f, 104f)
+                lineToRelative(-56f, 56f)
+                lineToRelative(-200f, -200f)
+                lineToRelative(200f, -200f)
+                lineToRelative(56f, 56f)
+                lineToRelative(-104f, 104f)
+                horizontalLineToRelative(252f)
+                quadToRelative(97f, 0f, 166.5f, 63f)
+                reflectiveQuadTo(800f, 540f)
+                reflectiveQuadToRelative(-69.5f, 157f)
+                reflectiveQuadTo(564f, 760f)
+                close()
+            }
+        }.build()
+
+        return _Undo!!
+    }
+
+private var _Undo: ImageVector? = null
+
+
+

--- a/core/designsystem/src/commonMain/kotlin/com/mshdabiola/designsystem/drawable/SynIcons.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/mshdabiola/designsystem/drawable/SynIcons.kt
@@ -23,8 +23,6 @@ import androidx.compose.material.icons.automirrored.rounded.Chat
 import androidx.compose.material.icons.automirrored.rounded.Label
 import androidx.compose.material.icons.automirrored.rounded.MenuOpen
 import androidx.compose.material.icons.automirrored.rounded.Note
-import androidx.compose.material.icons.automirrored.rounded.Redo
-import androidx.compose.material.icons.automirrored.rounded.Undo
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.Archive
@@ -142,8 +140,8 @@ object SynIcons {
     val ViewAgenda = Icons.Rounded.ViewAgenda
     val GridView = Icons.Rounded.GridView
     val CheckBoxOutlineBlank = Icons.Outlined.CheckBoxOutlineBlank
-    val Undo = Icons.AutoMirrored.Rounded.Undo
-    val Redo = Icons.AutoMirrored.Rounded.Redo
+    val Undo = com.mshdabiola.designsystem.drawable.Undo
+    val Redo = com.mshdabiola.designsystem.drawable.Redo
     val AccessTime = Icons.Rounded.AccessTime
     val Share = Icons.Rounded.Share
     val ContentCopy = Icons.Rounded.ContentCopy

--- a/core/model/src/commonMain/kotlin/com/mshdabiola/model/note/PenProperties.kt
+++ b/core/model/src/commonMain/kotlin/com/mshdabiola/model/note/PenProperties.kt
@@ -19,7 +19,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class PenProperties(
-    val colorIndex: Int = 0,
+    val colorIndex: Int = 22,
     val lineWidth: Int = 8,
     val lineCapIndex: Int = 0,
     val lineJoinIndex: Int = 0,

--- a/core/ui/src/androidMain/kotlin/com/mshdabiola/ui/RealLogics.kt
+++ b/core/ui/src/androidMain/kotlin/com/mshdabiola/ui/RealLogics.kt
@@ -154,19 +154,7 @@ class ReaLogics(
 
     override fun shareDrawing(bitmap: ImageBitmap) {
         // 1. Save ImageBitmap to a temporary file
-        val imageFile: File? = try {
-            val imageFileParentDir = File(context.cacheDir, "images")
-            imageFileParentDir.mkdirs()
-            val file = File(imageFileParentDir, "shared_drawing_${System.currentTimeMillis()}.png")
-            FileOutputStream(file).use { stream ->
-                val androidBitmap = bitmap.asAndroidBitmap()
-                androidBitmap.compress(Bitmap.CompressFormat.PNG, 90, stream)
-            }
-            file
-        } catch (e: IOException) {
-            e.printStackTrace()
-            null
-        }
+        val imageFile: File? = saveBitmapToCache(bitmap, "shared_drawing")
 
         if (imageFile != null) {
             val imageUri: Uri? = try {
@@ -204,20 +192,22 @@ class ReaLogics(
         }
     }
 
-    override fun copyDrawing(bitmap: ImageBitmap) {
-        val imageFile: File? = try {
+    private fun saveBitmapToCache(bitmap: ImageBitmap, filenamePrefix: String): File? {
+        return try {
             val imageFileParentDir = File(context.cacheDir, "images")
             imageFileParentDir.mkdirs()
-            val file = File(imageFileParentDir, "copied_drawing_${System.currentTimeMillis()}.png")
+            val file = File(imageFileParentDir, "${filenamePrefix}_${System.currentTimeMillis()}.png")
             FileOutputStream(file).use { stream ->
-                val androidBitmap = bitmap.asAndroidBitmap()
-                androidBitmap.compress(Bitmap.CompressFormat.PNG, 90, stream)
+                bitmap.asAndroidBitmap().compress(Bitmap.CompressFormat.PNG, 90, stream)
             }
             file
         } catch (e: IOException) {
-            e.printStackTrace()
+            android.util.Log.e("ReaLogics", "Failed to save bitmap to cache for $filenamePrefix", e)
             null
         }
+    }
+    override fun copyDrawing(bitmap: ImageBitmap) {
+        val imageFile: File? = saveBitmapToCache(bitmap, "copied_drawing")
 
         if (imageFile != null) {
             val imageUri: Uri? = try {

--- a/core/ui/src/androidMain/kotlin/com/mshdabiola/ui/RealLogics.kt
+++ b/core/ui/src/androidMain/kotlin/com/mshdabiola/ui/RealLogics.kt
@@ -173,7 +173,7 @@ class ReaLogics(
                 FileProvider.getUriForFile(
                     context,
                     "${context.packageName}.provider",
-                    imageFile
+                    imageFile,
                 )
             } catch (e: Exception) {
                 println("FileProvider Error: Is the file path covered by file_paths.xml?")
@@ -224,7 +224,7 @@ class ReaLogics(
                 FileProvider.getUriForFile(
                     context,
                     "${context.packageName}.provider",
-                    imageFile
+                    imageFile,
                 )
             } catch (e: Exception) {
                 println("FileProvider Error for copy: Is the file path covered by file_paths.xml?")

--- a/core/ui/src/androidMain/kotlin/com/mshdabiola/ui/RealLogics.kt
+++ b/core/ui/src/androidMain/kotlin/com/mshdabiola/ui/RealLogics.kt
@@ -19,6 +19,7 @@ import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
 import android.speech.RecognizerIntent
@@ -32,7 +33,6 @@ import androidx.core.app.ShareCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
-import coil3.Bitmap
 import com.mshdabiola.model.note.NotePad
 import java.io.File
 import java.io.FileOutputStream
@@ -153,14 +153,13 @@ class ReaLogics(
     override fun shareDrawing(bitmap: ImageBitmap) {
         // 1. Save ImageBitmap to a temporary file
         val imageFile: File? = try {
-            val cachePath = File(context.cacheDir, "images")
-            cachePath.mkdirs() // Create 'images' directory if it doesn't exist
-            val file = File(cachePath, "shared_drawing_${System.currentTimeMillis()}.png")
+            // CORRECTED LINE: Use context.cacheDir to match your file_paths.xml
+            val imageFileParentDir = File(context.cacheDir, "images")
+            imageFileParentDir.mkdirs() // Create 'images' directory if it doesn't exist
+            val file = File(imageFileParentDir, "shared_drawing_${System.currentTimeMillis()}.png")
             FileOutputStream(file).use { stream ->
-                // Convert Compose ImageBitmap to Android Graphics Bitmap
-                // Ensure your ImageBitmap is in a compatible format, e.g., ARGB_8888
                 val androidBitmap = bitmap.asAndroidBitmap()
-                androidBitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 90, stream)
+                androidBitmap.compress(Bitmap.CompressFormat.PNG, 90, stream)
             }
             file
         } catch (e: IOException) {
@@ -174,13 +173,16 @@ class ReaLogics(
                 FileProvider.getUriForFile(
                     context,
                     "${context.packageName}.provider", // Make sure this matches your AndroidManifest
-                    imageFile,
+                    imageFile // imageFile now correctly points to a path within the cache directory
                 )
-            } catch (e: Exception) {
+            } catch (e: Exception) { // Catch specifically IllegalArgumentException for debugging
+                println("FileProvider Error: Is the file path covered by file_paths.xml?")
+                println("File path trying to share: ${imageFile.absolutePath}")
                 e.printStackTrace()
                 null
             }
 
+            // ... rest of your sharing logic
             if (imageUri != null) {
                 // 3. Share using the content URI
                 val shareIntent = ShareCompat.IntentBuilder(context)
@@ -189,28 +191,19 @@ class ReaLogics(
                     .setChooserTitle("Share Drawing") // TODO: Move to string resources
                     .createChooserIntent()
                     .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION) // Grant read permission
+                    .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
 
                 if (shareIntent.resolveActivity(context.packageManager) != null) {
                     context.startActivity(shareIntent)
                 } else {
-                    // Handle case where no app can handle the share intent (e.g., show a Toast)
                     println("No app found to share the drawing.")
                 }
-
-                // Optionally, you can try to delete the temp file.
-                // However, the receiving app might need time to access it.
-                // A more robust way is to use a ContentObserver or clear cache periodically.
-                // For simplicity, we won't delete it immediately here.
-                // imageFile.deleteOnExit() // This might not always work as expected.
-
             } else {
                 println("Error getting content URI for the drawing.")
-                // Handle error (e.g., show a Toast to the user)
             }
         } else {
             println("Error saving drawing to a temporary file.")
-            // Handle error (e.g., show a Toast to the user)
         }
     }
+
 }

--- a/core/ui/src/androidMain/kotlin/com/mshdabiola/ui/RealLogics.kt
+++ b/core/ui/src/androidMain/kotlin/com/mshdabiola/ui/RealLogics.kt
@@ -26,12 +26,17 @@ import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.core.app.ShareCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
+import coil3.Bitmap
 import com.mshdabiola.model.note.NotePad
 import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
 
 class ReaLogics(
     val context: Context,
@@ -143,5 +148,69 @@ class ReaLogics(
             context.checkSelfPermission(
                 Manifest.permission.POST_NOTIFICATIONS,
             ) == PackageManager.PERMISSION_DENIED
+    }
+
+    override fun shareDrawing(bitmap: ImageBitmap) {
+        // 1. Save ImageBitmap to a temporary file
+        val imageFile: File? = try {
+            val cachePath = File(context.cacheDir, "images")
+            cachePath.mkdirs() // Create 'images' directory if it doesn't exist
+            val file = File(cachePath, "shared_drawing_${System.currentTimeMillis()}.png")
+            FileOutputStream(file).use { stream ->
+                // Convert Compose ImageBitmap to Android Graphics Bitmap
+                // Ensure your ImageBitmap is in a compatible format, e.g., ARGB_8888
+                val androidBitmap = bitmap.asAndroidBitmap()
+                androidBitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 90, stream)
+            }
+            file
+        } catch (e: IOException) {
+            e.printStackTrace()
+            null
+        }
+
+        if (imageFile != null) {
+            // 2. Get content URI using FileProvider
+            val imageUri: Uri? = try {
+                FileProvider.getUriForFile(
+                    context,
+                    "${context.packageName}.provider", // Make sure this matches your AndroidManifest
+                    imageFile,
+                )
+            } catch (e: Exception) {
+                e.printStackTrace()
+                null
+            }
+
+            if (imageUri != null) {
+                // 3. Share using the content URI
+                val shareIntent = ShareCompat.IntentBuilder(context)
+                    .setType("image/png")
+                    .setStream(imageUri)
+                    .setChooserTitle("Share Drawing") // TODO: Move to string resources
+                    .createChooserIntent()
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION) // Grant read permission
+
+                if (shareIntent.resolveActivity(context.packageManager) != null) {
+                    context.startActivity(shareIntent)
+                } else {
+                    // Handle case where no app can handle the share intent (e.g., show a Toast)
+                    println("No app found to share the drawing.")
+                }
+
+                // Optionally, you can try to delete the temp file.
+                // However, the receiving app might need time to access it.
+                // A more robust way is to use a ContentObserver or clear cache periodically.
+                // For simplicity, we won't delete it immediately here.
+                // imageFile.deleteOnExit() // This might not always work as expected.
+
+            } else {
+                println("Error getting content URI for the drawing.")
+                // Handle error (e.g., show a Toast to the user)
+            }
+        } else {
+            println("Error saving drawing to a temporary file.")
+            // Handle error (e.g., show a Toast to the user)
+        }
     }
 }

--- a/core/ui/src/androidMain/kotlin/com/mshdabiola/ui/RealLogics.kt
+++ b/core/ui/src/androidMain/kotlin/com/mshdabiola/ui/RealLogics.kt
@@ -16,6 +16,8 @@
 package com.mshdabiola.ui
 
 import android.Manifest
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -153,9 +155,8 @@ class ReaLogics(
     override fun shareDrawing(bitmap: ImageBitmap) {
         // 1. Save ImageBitmap to a temporary file
         val imageFile: File? = try {
-            // CORRECTED LINE: Use context.cacheDir to match your file_paths.xml
             val imageFileParentDir = File(context.cacheDir, "images")
-            imageFileParentDir.mkdirs() // Create 'images' directory if it doesn't exist
+            imageFileParentDir.mkdirs()
             val file = File(imageFileParentDir, "shared_drawing_${System.currentTimeMillis()}.png")
             FileOutputStream(file).use { stream ->
                 val androidBitmap = bitmap.asAndroidBitmap()
@@ -168,27 +169,24 @@ class ReaLogics(
         }
 
         if (imageFile != null) {
-            // 2. Get content URI using FileProvider
             val imageUri: Uri? = try {
                 FileProvider.getUriForFile(
                     context,
-                    "${context.packageName}.provider", // Make sure this matches your AndroidManifest
-                    imageFile // imageFile now correctly points to a path within the cache directory
+                    "${context.packageName}.provider",
+                    imageFile
                 )
-            } catch (e: Exception) { // Catch specifically IllegalArgumentException for debugging
+            } catch (e: Exception) {
                 println("FileProvider Error: Is the file path covered by file_paths.xml?")
                 println("File path trying to share: ${imageFile.absolutePath}")
                 e.printStackTrace()
                 null
             }
 
-            // ... rest of your sharing logic
             if (imageUri != null) {
-                // 3. Share using the content URI
                 val shareIntent = ShareCompat.IntentBuilder(context)
                     .setType("image/png")
                     .setStream(imageUri)
-                    .setChooserTitle("Share Drawing") // TODO: Move to string resources
+                    .setChooserTitle("Share Drawing")
                     .createChooserIntent()
                     .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
@@ -206,4 +204,46 @@ class ReaLogics(
         }
     }
 
+    override fun copyDrawing(bitmap: ImageBitmap) {
+        val imageFile: File? = try {
+            val imageFileParentDir = File(context.cacheDir, "images")
+            imageFileParentDir.mkdirs()
+            val file = File(imageFileParentDir, "copied_drawing_${System.currentTimeMillis()}.png")
+            FileOutputStream(file).use { stream ->
+                val androidBitmap = bitmap.asAndroidBitmap()
+                androidBitmap.compress(Bitmap.CompressFormat.PNG, 90, stream)
+            }
+            file
+        } catch (e: IOException) {
+            e.printStackTrace()
+            null
+        }
+
+        if (imageFile != null) {
+            val imageUri: Uri? = try {
+                FileProvider.getUriForFile(
+                    context,
+                    "${context.packageName}.provider",
+                    imageFile
+                )
+            } catch (e: Exception) {
+                println("FileProvider Error for copy: Is the file path covered by file_paths.xml?")
+                println("File path trying to copy: ${imageFile.absolutePath}")
+                e.printStackTrace()
+                null
+            }
+
+            if (imageUri != null) {
+                val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                val clipData = ClipData.newUri(context.contentResolver, "Image", imageUri)
+                clipboardManager.setPrimaryClip(clipData)
+                // Optionally, show a toast or notification that image has been copied
+                println("Drawing copied to clipboard.")
+            } else {
+                println("Error getting content URI for copying the drawing.")
+            }
+        } else {
+            println("Error saving drawing to a temporary file for copying.")
+        }
+    }
 }

--- a/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/DrawingBar.kt
+++ b/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/DrawingBar.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -37,7 +36,6 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.runtime.Composable
@@ -387,14 +385,13 @@ fun ColorAndWidth(
     onlineClick: (Int) -> Unit = {},
 ) {
     Column(modifier = Modifier.padding(8.dp).testTag("${DrawingBarTestTags.COLOR_WIDTH_SECTION_ROOT}_$index")) {
-
         FlowRow(
             modifier = Modifier
                 .fillMaxWidth()
                 .testTag("${DrawingBarTestTags.COLOR_SELECTOR_LAYOUT}_$index"),
             verticalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.CenterVertically),
             horizontalArrangement = Arrangement.Center,
-            itemVerticalAlignment = Alignment.CenterVertically
+            itemVerticalAlignment = Alignment.CenterVertically,
         ) {
             colors.forEachIndexed { index, color ->
                 Box(

--- a/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/DrawingBar.kt
+++ b/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/DrawingBar.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -53,6 +54,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag // Added import
 import androidx.compose.ui.unit.dp
+import com.mshdabiola.designsystem.component.SynTabRow
 import com.mshdabiola.designsystem.component.SynTextButton
 import com.mshdabiola.model.note.PenProperties
 import com.mshdabiola.model.testtag.DrawingBarTestTags // Added import
@@ -85,9 +87,6 @@ fun DrawingBar(
     var penProperties by remember {
         mutableStateOf(
             PenProperties(
-                colorIndex = 1,
-                colorAlphaIndex = 1f,
-                lineCapIndex = 0,
                 lineWidth = with(density) {
                     4.dp.roundToPx()
                 },
@@ -136,7 +135,7 @@ fun DrawingBar(
     val coroutineScope = rememberCoroutineScope()
     Surface(modifier.testTag(DrawingBarTestTags.ROOT)) {
         Column {
-            SecondaryTabRow(
+            SynTabRow(
                 pagerState.currentPage,
                 Modifier.testTag(DrawingBarTestTags.TAB_ROW),
             ) {
@@ -387,13 +386,15 @@ fun ColorAndWidth(
     onColorClick: (Int) -> Unit = {},
     onlineClick: (Int) -> Unit = {},
 ) {
-    Column(modifier = Modifier.testTag("${DrawingBarTestTags.COLOR_WIDTH_SECTION_ROOT}_$index")) {
+    Column(modifier = Modifier.padding(8.dp).testTag("${DrawingBarTestTags.COLOR_WIDTH_SECTION_ROOT}_$index")) {
+
         FlowRow(
             modifier = Modifier
                 .fillMaxWidth()
-                .align(Alignment.CenterHorizontally)
                 .testTag("${DrawingBarTestTags.COLOR_SELECTOR_LAYOUT}_$index"),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp, alignment = Alignment.CenterVertically),
+            horizontalArrangement = Arrangement.Center,
+            itemVerticalAlignment = Alignment.CenterVertically
         ) {
             colors.forEachIndexed { index, color ->
                 Box(
@@ -403,13 +404,14 @@ fun ColorAndWidth(
                         }
                         .clip(CircleShape)
                         .background(color)
-                        .size(if (index == currentColor) 34.dp else 30.dp)
+                        .size(if (index == currentColor) 34.dp else 26.dp)
                         .testTag("${DrawingBarTestTags.COLOR_SELECTOR_ITEM_PREFIX}_$index"),
 
                 )
                 Spacer(modifier = Modifier.width(16.dp))
             }
         }
+        val color = MaterialTheme.colorScheme.inverseSurface
 
         val context = LocalDensity.current
         Row(
@@ -433,8 +435,8 @@ fun ColorAndWidth(
                         }
                         .clip(CircleShape)
                         .border(
-                            1.dp,
-                            if (currentWidthPx == currentWidth) Color.Gray else Color.Transparent,
+                            2.dp,
+                            if (currentWidthPx == currentWidth) color else Color.Transparent,
                             CircleShape,
                         )
                         .size(30.dp)
@@ -445,7 +447,7 @@ fun ColorAndWidth(
                         modifier =
                         Modifier
                             .clip(CircleShape)
-                            .background(Color.Black)
+                            .background(color)
                             .align(Alignment.Center)
                             .padding(2.dp)
                             .size(((it + 1) * 2).dp),

--- a/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/DrawingController.kt
+++ b/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/DrawingController.kt
@@ -67,7 +67,7 @@ val colors = arrayOf(
     Color(0xFF795548), // Brown 500
     Color.Gray,
     Color.Black,
-    Color.White
+    Color.White,
 
 )
 

--- a/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/DrawingController.kt
+++ b/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/DrawingController.kt
@@ -33,19 +33,41 @@ import com.mshdabiola.model.note.PenProperties as DrawingProperties
 import com.mshdabiola.model.note.Point as Coordinate
 
 val colors = arrayOf(
-    Color.Black,
+    // Reds & Pinks
     Color.Red,
-    Color.Green,
-    Color.Blue,
-    Color.Magenta,
-    Color.Cyan,
+    Color(0xFFE91E63), // Pink
+    Color(0xFFF44336), // Material Red 500
+    Color(0xFFFF7043), // Deep Orange 400 (Coral-like)
+
+    // Oranges & Yellows
+    Color(0xFFFF9800), // Orange 500
     Color.Yellow,
-    Color(0xFF651FFF),
-    Color(0xFFD500F9),
-    Color(0xFFFFEA00),
-    Color(0xFF1DE9B6),
-    Color(0xFFF50057),
-    Color(0xFFFF3D00),
+    Color(0xFFFFEB3B), // Material Yellow 500
+    Color(0xFFCDDC39), // Lime 500
+
+    // Greens
+    Color.Green,
+    Color(0xFF4CAF50), // Material Green 500
+    Color(0xFF009688), // Teal 500
+    Color(0xFF8BC34A), // Light Green 500
+
+    // Blues
+    Color.Blue,
+    Color(0xFF2196F3), // Material Blue 500
+    Color(0xFF03A9F4), // Light Blue 500
+    Color(0xFF3F51B5), // Indigo 500
+
+    // Purples & Magentas
+    Color.Magenta,
+    Color(0xFF9C27B0), // Purple 500
+    Color(0xFF673AB7), // Deep Purple 500
+    Color(0xFF7B1FA2), // Purple 700 (Darker Purple)
+
+    // Browns & Grays & Others
+    Color(0xFF795548), // Brown 500
+    Color.Gray,
+    Color.Black,
+    Color.White
 
 )
 

--- a/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/Logics.kt
+++ b/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/Logics.kt
@@ -33,4 +33,5 @@ interface Logics {
     fun checkNotificationPermission(): Boolean
 
     fun shareDrawing(bitmap: ImageBitmap)
+    fun copyDrawing(bitmap: ImageBitmap)
 }

--- a/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/Logics.kt
+++ b/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/Logics.kt
@@ -15,6 +15,7 @@
  */
 package com.mshdabiola.ui
 
+import androidx.compose.ui.graphics.ImageBitmap
 import com.mshdabiola.model.note.NotePad
 
 interface Logics {
@@ -30,4 +31,6 @@ interface Logics {
     fun askForNotificationPermission()
 
     fun checkNotificationPermission(): Boolean
+
+    fun shareDrawing(bitmap: ImageBitmap)
 }

--- a/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/NewSelectionTools.kt
+++ b/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/NewSelectionTools.kt
@@ -1,0 +1,358 @@
+/*
+ * Designed and developed by 2024 mshdabiola (lawal abiola)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mshdabiola.ui
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.platform.testTag // Added import
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import com.mshdabiola.designsystem.drawable.SynIcons
+import com.mshdabiola.designsystem.theme.SynTheme
+import com.mshdabiola.model.testtag.NewSelectionToolsTestTags // Added import
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import kotlin.math.PI
+import kotlin.math.atan2
+import kotlin.math.roundToInt
+
+@Composable
+fun ResizableRectangleWithHandles2(
+    rectangle: MutableState<Rect>,
+    rotationAngle: MutableState<Float>,
+) {
+    val density = LocalDensity.current
+    val configuration = LocalWindowInfo.current
+    val screenWidthDp = configuration.containerSize.width
+    val screenHeightDp = configuration.containerSize.height
+
+    with(density) {
+        val screenWidthPx = screenWidthDp
+        val screenHeightPx = screenHeightDp
+
+        val handleSize = 24.dp
+        val handleSizePx = handleSize.toPx()
+        val minDimensionPx = handleSizePx * 2
+
+        val rotationPivotX = (rectangle.value.width + handleSizePx) / 2f
+        val rotationPivotY = (rectangle.value.height + handleSizePx.times(2.5f)) / 2f
+
+        Box(
+            Modifier
+                .graphicsLayer(
+                    rotationZ = rotationAngle.value,
+                    transformOrigin = TransformOrigin(
+                        rotationPivotX / (rectangle.value.width + handleSizePx),
+                        rotationPivotY / (rectangle.value.height + handleSizePx),
+                    ),
+                )
+                .fillMaxSize()
+                .testTag(NewSelectionToolsTestTags.RESIZABLE_RECT_ROOT),
+        ) {
+            Column(
+                modifier = Modifier
+                    .offset {
+                        IntOffset(
+                            rectangle.value.topLeft.x.roundToInt(),
+                            rectangle.value.topLeft.y.roundToInt(),
+                        )
+                    }
+                    .testTag(NewSelectionToolsTestTags.RESIZABLE_RECT_OFFSET_COLUMN),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(handleSize)
+                        .pointerInput(Unit) {
+                            detectDragGestures { change, dragAmount ->
+                                change.consume()
+                                val rectCenterX = rectangle.value.center.x
+                                val rectCenterY = rectangle.value.center.y
+                                val prevPos = change.previousPosition - Offset(rectCenterX, rectCenterY)
+                                val currentPos = change.position - Offset(rectCenterX, rectCenterY)
+                                val prevAngle = atan2(prevPos.y, prevPos.x)
+                                val currentAngle = atan2(currentPos.y, currentPos.x)
+                                val angleDiff =
+                                    ((currentAngle - prevAngle) * 180.0 / PI).toFloat()
+                                rotationAngle.value += angleDiff
+                            }
+                        }
+                        .background(Color.Blue, CircleShape)
+                        .testTag(NewSelectionToolsTestTags.ROTATION_HANDLE_ROOT),
+                ) {
+                    Icon(
+                        SynIcons.Refresh,
+                        contentDescription = "Rotate",
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(2.dp)
+                            .testTag(NewSelectionToolsTestTags.ROTATION_HANDLE_ICON),
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    )
+                }
+                VerticalDivider(
+                    modifier = Modifier.height(handleSize / 2),
+                    thickness = 4.dp,
+                    color = Color.Blue,
+                )
+                Box(
+                    modifier = Modifier
+                        .size(
+                            (rectangle.value.width.toDp() + handleSize),
+                            (rectangle.value.height.toDp() + handleSize),
+                        )
+                        .pointerInput(Unit) {
+                            detectDragGestures { change, dragAmount ->
+                                change.consume()
+                                rectangle.value = rectangle.value.translate(dragAmount.x, dragAmount.y)
+                            }
+                        }
+                        .testTag(NewSelectionToolsTestTags.MAIN_DRAGGABLE_RESIZABLE_AREA),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(
+                                rectangle.value.width.toDp(),
+                                rectangle.value.height.toDp(),
+                            )
+                            .align(Alignment.Center)
+                            .border(4.dp, Color.Blue)
+                            .testTag(NewSelectionToolsTestTags.RESIZABLE_BORDER_BOX),
+                    )
+
+                    // Top-Left handle
+                    DraggableHandle(
+                        modifier = Modifier
+                            .size(handleSize)
+                            .align(Alignment.TopStart)
+                            .testTag(NewSelectionToolsTestTags.HANDLE_TOP_LEFT),
+                    ) { dragAmount ->
+                        val newWidth = (rectangle.value.width - 2 * dragAmount.x)
+                            .coerceIn(minDimensionPx, screenWidthPx - handleSizePx)
+                        val newHeight = (rectangle.value.height - 2 * dragAmount.y)
+                            .coerceIn(minDimensionPx, screenHeightPx - handleSizePx.times(2.5f))
+                        val newTopLeft = Offset(
+                            rectangle.value.center.x - newWidth / 2,
+                            rectangle.value.center.y - newHeight / 2,
+                        )
+                        rectangle.value = Rect(newTopLeft, Size(newWidth, newHeight))
+                    }
+                    // Top-Center handle
+                    DraggableHandle(
+                        modifier = Modifier
+                            .size(handleSize)
+                            .align(Alignment.TopCenter)
+                            .testTag(NewSelectionToolsTestTags.HANDLE_TOP_CENTER),
+                    ) { dragAmount ->
+                        val newHeight = (rectangle.value.height - 2 * dragAmount.y)
+                            .coerceIn(minDimensionPx, screenHeightPx - handleSizePx.times(2.5f))
+                        val newTopLeft = Offset(rectangle.value.topLeft.x, rectangle.value.center.y - newHeight / 2)
+                        rectangle.value =
+                            Rect(
+                                newTopLeft,
+                                Size(
+                                    rectangle.value.width.coerceIn(
+                                        minDimensionPx,
+                                        screenWidthPx - handleSizePx,
+                                    ),
+                                    newHeight,
+                                ),
+                            )
+                    }
+                    // Top-End handle
+                    DraggableHandle(
+                        modifier = Modifier
+                            .size(handleSize)
+                            .align(Alignment.TopEnd)
+                            .testTag(NewSelectionToolsTestTags.HANDLE_TOP_END),
+                    ) { dragAmount ->
+                        val newWidth = (rectangle.value.width + 2 * dragAmount.x)
+                            .coerceIn(minDimensionPx, screenWidthPx - handleSizePx)
+                        val newHeight = (rectangle.value.height - 2 * dragAmount.y)
+                            .coerceIn(minDimensionPx, screenHeightPx - handleSizePx.times(2.5f))
+                        val newTopLeft = Offset(
+                            rectangle.value.center.x - newWidth / 2,
+                            rectangle.value.center.y - newHeight / 2,
+                        )
+                        rectangle.value = Rect(newTopLeft, Size(newWidth, newHeight))
+                    }
+                    // Center-Start handle
+                    DraggableHandle(
+                        modifier = Modifier
+                            .size(handleSize)
+                            .align(Alignment.CenterStart)
+                            .testTag(NewSelectionToolsTestTags.HANDLE_CENTER_START),
+                    ) { dragAmount ->
+                        val newWidth = (rectangle.value.width - 2 * dragAmount.x)
+                            .coerceIn(minDimensionPx, screenWidthPx - handleSizePx)
+                        val newTopLeft = Offset(rectangle.value.center.x - newWidth / 2, rectangle.value.topLeft.y)
+                        rectangle.value =
+                            Rect(
+                                newTopLeft,
+                                Size(
+                                    newWidth,
+                                    rectangle.value.height.coerceIn(
+                                        minDimensionPx,
+                                        screenHeightPx - handleSizePx,
+                                    ),
+                                ),
+                            )
+                    }
+                    // Center-End handle
+                    DraggableHandle(
+                        modifier = Modifier
+                            .size(handleSize)
+                            .align(Alignment.CenterEnd)
+                            .testTag(NewSelectionToolsTestTags.HANDLE_CENTER_END),
+                    ) { dragAmount ->
+                        val newWidth = (rectangle.value.width + 2 * dragAmount.x)
+                            .coerceIn(minDimensionPx, screenWidthPx - handleSizePx)
+                        val newTopLeft = Offset(rectangle.value.center.x - newWidth / 2, rectangle.value.topLeft.y)
+                        rectangle.value =
+                            Rect(
+                                newTopLeft,
+                                Size(
+                                    newWidth,
+                                    rectangle.value.height.coerceIn(
+                                        minDimensionPx,
+                                        screenHeightPx - handleSizePx,
+                                    ),
+                                ),
+                            )
+                    }
+                    // Bottom-Start handle
+                    DraggableHandle(
+                        modifier = Modifier
+                            .size(handleSize)
+                            .align(Alignment.BottomStart)
+                            .testTag(NewSelectionToolsTestTags.HANDLE_BOTTOM_START),
+                    ) { dragAmount ->
+                        val newWidth = (rectangle.value.width - 2 * dragAmount.x)
+                            .coerceIn(minDimensionPx, screenWidthPx - handleSizePx)
+                        val newHeight = (rectangle.value.height + 2 * dragAmount.y)
+                            .coerceIn(minDimensionPx, screenHeightPx - handleSizePx.times(2.5f))
+                        val newTopLeft = Offset(
+                            rectangle.value.center.x - newWidth / 2,
+                            rectangle.value.center.y - newHeight / 2,
+                        )
+                        rectangle.value = Rect(newTopLeft, Size(newWidth, newHeight))
+                    }
+                    // Bottom-Center handle
+                    DraggableHandle(
+                        modifier = Modifier
+                            .size(handleSize)
+                            .align(Alignment.BottomCenter)
+                            .testTag(NewSelectionToolsTestTags.HANDLE_BOTTOM_CENTER),
+                    ) { dragAmount ->
+                        val newHeight = (rectangle.value.height + 2 * dragAmount.y)
+                            .coerceIn(minDimensionPx, screenHeightPx - handleSizePx.times(2.5f))
+                        val newTopLeft = Offset(rectangle.value.topLeft.x, rectangle.value.center.y - newHeight / 2)
+                        rectangle.value =
+                            Rect(
+                                newTopLeft,
+                                Size(
+                                    rectangle.value.width.coerceIn(
+                                        minDimensionPx,
+                                        screenWidthPx - handleSizePx,
+                                    ),
+                                    newHeight,
+                                ),
+                            )
+                    }
+                    // Bottom-End handle
+                    DraggableHandle(
+                        modifier = Modifier
+                            .size(handleSize)
+                            .align(Alignment.BottomEnd)
+                            .testTag(NewSelectionToolsTestTags.HANDLE_BOTTOM_END),
+                    ) { dragAmount ->
+                        val newWidth = (rectangle.value.width + 2 * dragAmount.x)
+                            .coerceIn(minDimensionPx, screenWidthPx - handleSizePx)
+                        val newHeight = (rectangle.value.height + 2 * dragAmount.y)
+                            .coerceIn(minDimensionPx, screenHeightPx - handleSizePx.times(2.5f))
+                        val newTopLeft = Offset(
+                            rectangle.value.center.x - newWidth / 2,
+                            rectangle.value.center.y - newHeight / 2,
+                        )
+                        rectangle.value = Rect(newTopLeft, Size(newWidth, newHeight))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun DraggableHandle(
+    modifier: Modifier = Modifier,
+    onDrag: (dragAmount: Offset) -> Unit, // dragAmount is in pixels
+) {
+    Box(
+        modifier = modifier // If DRAGGABLE_HANDLE_ROOT is defined, it would be applied here.
+            .background(Color.Blue, RoundedCornerShape(2.dp))
+            .border(1.dp, Color.White, RoundedCornerShape(2.dp))
+            .pointerInput(Unit) {
+                detectDragGestures { change, dragAmount ->
+                    change.consume()
+                    onDrag(dragAmount) // Pass drag amount in pixels
+                }
+            },
+    ) {
+        // No content needed, it's just a visual box for the handle
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ResizableRectangleWithHandlesPreview() {
+    val rectangle = remember { mutableStateOf(Rect(0f, 0f, 100f, 100f)) }
+    val rotationAngle = remember { mutableFloatStateOf(0f) }
+
+    SynTheme {
+        ResizableRectangleWithHandles2(
+            rectangle = rectangle,
+            rotationAngle = rotationAngle,
+        )
+    }
+}

--- a/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/OutDrawing.kt
+++ b/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/OutDrawing.kt
@@ -1,0 +1,155 @@
+package com.mshdabiola.ui
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.PaintingStyle
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.round
+import kotlin.math.max
+import kotlin.math.min
+import com.mshdabiola.model.note.Path as DrawingPath
+
+/**
+ * Creates a new ImageBitmap with the given paths drawn onto a copy of the original bitmap.
+ *
+ * @param originalBitmap The base image.
+ * @param pathsToDraw The paths to draw onto the image.
+ * @param density Current density, needed for proper stroke width scaling if your
+ *                stroke widths are defined in Dp. If they are already in pixels,
+ *                you might not need this or can use Density(1f).
+ * @return A new ImageBitmap with the paths rendered on it.
+ */
+fun drawPathsOnImage(
+    originalBitmap: ImageBitmap,
+    pathsToDraw: List<DrawingPath>,
+    density: Density, // Important for consistent stroke width if defined in Dp
+): ImageBitmap {
+    // Create a mutable copy of the original bitmap to draw on
+    // Or, if you want to draw on a new blank bitmap of the same size:
+    // val outputBitmap = ImageBitmap(originalBitmap.width, originalBitmap.height, ImageBitmapConfig.Argb8888)
+    val outputBitmap = ImageBitmap(
+        width = originalBitmap.width,
+        height = originalBitmap.height,
+        config = originalBitmap.config, // Use the same config
+    )
+
+    val canvas = Canvas(outputBitmap) // Create a Canvas backed by the new bitmap
+
+    // Optional: Draw the original image onto the new canvas first if you want it as a background
+    // If originalBitmap is just a background color or placeholder, you might skip this
+    // or fill with a background color.
+    // For this example, let's assume we are drawing ON TOP of the original's content.
+    // To do that, we first draw the originalBitmap onto our outputBitmap's canvas.
+    canvas.drawImageRect(
+        image = originalBitmap,
+        dstOffset = Offset.Zero.round(), // Draw at top-left
+        dstSize = IntSize(originalBitmap.width, originalBitmap.height),
+        paint = Paint(), // Default paint
+    )
+
+
+    // --- Transformation Logic (similar to BoardViewer, but adapted for ImageBitmap) ---
+    if (pathsToDraw.isEmpty()) {
+        return outputBitmap // Return the bitmap (possibly with original image drawn)
+    }
+
+    var minX = Float.MAX_VALUE
+    var minY = Float.MAX_VALUE
+    var maxX = Float.MIN_VALUE
+    var maxY = Float.MIN_VALUE
+
+    pathsToDraw.forEach { drawingPath ->
+        if (drawingPath.penProperties.isPen && drawingPath.paths.isNotEmpty()) {
+            drawingPath.paths.forEach { point ->
+                minX = min(minX, point.x)
+                minY = min(minY, point.y)
+                maxX = max(maxX, point.x)
+                maxY = max(maxY, point.y)
+            }
+        } else if (!drawingPath.path.isEmpty) { // Assuming your DrawingPath has a compose Path
+            val r = drawingPath.path.getBounds()
+            minX = min(minX, r.left)
+            minY = min(minY, r.top)
+            maxX = max(maxX, r.right)
+            maxY = max(maxY, r.bottom)
+        }
+    }
+
+    if (minX == Float.MAX_VALUE) return outputBitmap // No valid path points
+
+    val drawingWidth = maxX - minX
+    val drawingHeight = maxY - minY
+
+    if (drawingWidth <= 0 || drawingHeight <= 0) return outputBitmap
+
+    val imageCanvasWidth = outputBitmap.width.toFloat()
+    val imageCanvasHeight = outputBitmap.height.toFloat()
+
+    val scaleX = imageCanvasWidth / drawingWidth
+    val scaleY = imageCanvasHeight / drawingHeight
+    val scale = min(scaleX, scaleY) // Fit and maintain aspect ratio
+
+    val scaledDrawingWidth = drawingWidth * scale
+    val scaledDrawingHeight = drawingHeight * scale
+
+    val translateX = (imageCanvasWidth - scaledDrawingWidth) / 2f - (minX * scale)
+    val translateY = (imageCanvasHeight - scaledDrawingHeight) / 2f - (minY * scale)
+    // --- End Transformation Logic ---
+
+
+    canvas.save() // Save current canvas state
+    canvas.translate(translateX, translateY)
+    canvas.scale(scale, scale) // Scale around the original drawing's top-left
+
+    pathsToDraw.forEach { drawingPath ->
+        val paint = Paint().apply {
+            this.color = drawingPath.color
+            this.style = PaintingStyle.Stroke
+            this.strokeWidth = max(0.5f, drawingPath.strokeWidth.width * scale) // Scale stroke width
+            this.strokeCap = drawingPath.strokeWidth.cap
+            this.strokeJoin = drawingPath.strokeWidth.join
+            // Note: PathEffect might also need scaling depending on its nature.
+            // This is simpler for the ImageBitmap canvas.
+        }
+
+        if (drawingPath.penProperties.isPen) {
+            if (drawingPath.paths.size > 1) {
+                // For pen, we might need to construct a Path object to draw smoothly
+                // or draw line segments like in BoardViewer.
+                // For simplicity here, let's draw line segments. Tapering can also be added.
+                val scaledBaseStrokeWidth = max(0.5f, drawingPath.strokeWidth.width * scale)
+                val taperSegments = 30
+                val minStrokeFactor = 0.1f
+
+                for (i in 0 until drawingPath.paths.size - 1) {
+                    val start = drawingPath.paths[i]
+                    val end = drawingPath.paths[i + 1]
+
+                    val segmentsFromEnd = drawingPath.paths.size - 1 - i
+                    val currentStrokeWidthPx = if (segmentsFromEnd <= taperSegments) {
+                        val taperFactor = (segmentsFromEnd - 1).toFloat() / taperSegments.toFloat()
+                        max(
+                            scaledBaseStrokeWidth * minStrokeFactor,
+                            scaledBaseStrokeWidth * taperFactor,
+                        )
+                    } else {
+                        scaledBaseStrokeWidth
+                    }
+                    paint.strokeWidth = max(0.5f, currentStrokeWidthPx)
+
+                    canvas.drawLine(start, end, paint)
+                }
+            }
+        } else {
+            // Ensure drawingPath.path is an androidx.compose.ui.graphics.Path
+            canvas.drawPath(drawingPath.path, paint)
+        }
+    }
+
+    canvas.restore() // Restore canvas state
+
+    return outputBitmap
+}

--- a/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/OutDrawing.kt
+++ b/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/OutDrawing.kt
@@ -1,3 +1,18 @@
+/*
+ * Designed and developed by 2024 mshdabiola (lawal abiola)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mshdabiola.ui
 
 import androidx.compose.ui.geometry.Offset
@@ -50,7 +65,6 @@ fun drawPathsOnImage(
         paint = Paint(), // Default paint
     )
 
-
     // --- Transformation Logic (similar to BoardViewer, but adapted for ImageBitmap) ---
     if (pathsToDraw.isEmpty()) {
         return outputBitmap // Return the bitmap (possibly with original image drawn)
@@ -99,13 +113,18 @@ fun drawPathsOnImage(
     val translateY = (imageCanvasHeight - scaledDrawingHeight) / 2f - (minY * scale)
     // --- End Transformation Logic ---
 
-
     canvas.save() // Save current canvas state
     canvas.translate(translateX, translateY)
     canvas.scale(scale, scale) // Scale around the original drawing's top-left
-    canvas.drawRect(minX,minY,maxX,maxY,Paint().apply {
-        color= androidx.compose.ui.graphics.Color.White
-    })
+    canvas.drawRect(
+        minX,
+        minY,
+        maxX,
+        maxY,
+        Paint().apply {
+            color = androidx.compose.ui.graphics.Color.White
+        },
+    )
     pathsToDraw.forEach { drawingPath ->
         val paint = Paint().apply {
             this.color = drawingPath.color

--- a/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/OutDrawing.kt
+++ b/core/ui/src/commonMain/kotlin/com/mshdabiola/ui/OutDrawing.kt
@@ -103,7 +103,9 @@ fun drawPathsOnImage(
     canvas.save() // Save current canvas state
     canvas.translate(translateX, translateY)
     canvas.scale(scale, scale) // Scale around the original drawing's top-left
-
+    canvas.drawRect(minX,minY,maxX,maxY,Paint().apply {
+        color= androidx.compose.ui.graphics.Color.White
+    })
     pathsToDraw.forEach { drawingPath ->
         val paint = Paint().apply {
             this.color = drawingPath.color

--- a/core/ui/src/jvmMain/kotlin/com/mshdabiola/ui/LogicComposable.jvm.kt
+++ b/core/ui/src/jvmMain/kotlin/com/mshdabiola/ui/LogicComposable.jvm.kt
@@ -41,7 +41,7 @@ actual fun getPlatformLogics(
     )
     return remember {
         RealLogics(
-            pickerLauncher = pickerLauncher,
+            imageSelectedCallback = saveImage,
             outputVoice = outputVoice,
             savePhoto = savePhoto,
             onNotification = onNotification,

--- a/core/ui/src/jvmMain/kotlin/com/mshdabiola/ui/RealLogics.kt
+++ b/core/ui/src/jvmMain/kotlin/com/mshdabiola/ui/RealLogics.kt
@@ -17,17 +17,16 @@ package com.mshdabiola.ui
 
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toAwtImage
-// import androidx.compose.ui.res.loadImageBitmap // Keep if used elsewhere
 import com.mshdabiola.model.note.NotePad
 import java.awt.Desktop
 import java.awt.FileDialog
 import java.awt.Frame
-import java.awt.Image // Required for ImageTransferable
-import java.awt.Toolkit // Required for Clipboard
-import java.awt.datatransfer.Clipboard // Required for Clipboard
-import java.awt.datatransfer.DataFlavor // Required for ImageTransferable
-import java.awt.datatransfer.Transferable // Required for ImageTransferable
-import java.awt.datatransfer.UnsupportedFlavorException // Required for ImageTransferable
+import java.awt.Image
+import java.awt.Toolkit
+import java.awt.datatransfer.Clipboard
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
 import java.awt.image.BufferedImage
 import java.io.File
 import java.io.FilenameFilter
@@ -57,7 +56,7 @@ class RealLogics(
     val outputVoice: (String, String) -> Unit = { _, _ -> },
     val savePhoto: () -> Unit = {},
     val onNotification: () -> Unit = {},
-    val imageSelectedCallback: (String) -> Unit = { _ -> }
+    val imageSelectedCallback: (String) -> Unit = { _ -> },
 ) : Logics {
     override fun openUrl(url: String) {
         val desktop = Desktop.getDesktop()

--- a/core/ui/src/jvmMain/kotlin/com/mshdabiola/ui/RealLogics.kt
+++ b/core/ui/src/jvmMain/kotlin/com/mshdabiola/ui/RealLogics.kt
@@ -17,6 +17,7 @@ package com.mshdabiola.ui
 
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toAwtImage
+import androidx.compose.ui.res.loadImageBitmap
 import com.mohamedrejeb.calf.picker.FilePickerLauncher
 import com.mshdabiola.model.note.NotePad
 import java.awt.Desktop
@@ -24,15 +25,18 @@ import java.awt.FileDialog
 import java.awt.Frame
 import java.awt.image.BufferedImage
 import java.io.File
+import java.io.FilenameFilter
 import java.io.IOException
 import java.net.URI
 import javax.imageio.ImageIO
+import kotlin.text.endsWith
+import kotlin.text.lowercase
 
 class RealLogics(
-    val pickerLauncher: FilePickerLauncher,
     val outputVoice: (String, String) -> Unit = { _, _ -> },
     val savePhoto: () -> Unit = {},
     val onNotification: () -> Unit = {},
+    val imageSelectedCallback: (String) -> Unit = { _ -> }
 ) : Logics {
     override fun openUrl(url: String) {
         val desktop = Desktop.getDesktop()
@@ -93,7 +97,32 @@ class RealLogics(
     }
 
     override fun chooseImage() {
-        pickerLauncher.launch()
+        val frame: Frame? = null // Or get your main app Frame if available
+        // Configure FileDialog for loading/opening a file
+        val fileDialog = FileDialog(frame, "Select Image File", FileDialog.LOAD)
+
+        // Optional: Set a filename filter to show only image files
+        fileDialog.filenameFilter = FilenameFilter { _, name ->
+            val lowercaseName = name.lowercase()
+            lowercaseName.endsWith(".png") ||
+                lowercaseName.endsWith(".jpg") ||
+                lowercaseName.endsWith(".jpeg") ||
+                lowercaseName.endsWith(".gif") ||
+                lowercaseName.endsWith(".bmp")
+        }
+
+        fileDialog.isVisible = true // Show the dialog (this is blocking)
+
+        val directory = fileDialog.directory
+        val filename = fileDialog.file
+
+        if (directory != null && filename != null) {
+            val selectedFile = File(directory, filename)
+            println("Selected file: ${selectedFile.absolutePath}")
+           imageSelectedCallback(selectedFile.absolutePath)
+        } else {
+            println("No file selected or dialog cancelled.")
+        }
     }
 
     override fun shareNote(notePad: NotePad) {

--- a/core/ui/src/jvmMain/kotlin/com/mshdabiola/ui/RealLogics.kt
+++ b/core/ui/src/jvmMain/kotlin/com/mshdabiola/ui/RealLogics.kt
@@ -17,20 +17,41 @@ package com.mshdabiola.ui
 
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.toAwtImage
-import androidx.compose.ui.res.loadImageBitmap
-import com.mohamedrejeb.calf.picker.FilePickerLauncher
+// import androidx.compose.ui.res.loadImageBitmap // Keep if used elsewhere
 import com.mshdabiola.model.note.NotePad
 import java.awt.Desktop
 import java.awt.FileDialog
 import java.awt.Frame
+import java.awt.Image // Required for ImageTransferable
+import java.awt.Toolkit // Required for Clipboard
+import java.awt.datatransfer.Clipboard // Required for Clipboard
+import java.awt.datatransfer.DataFlavor // Required for ImageTransferable
+import java.awt.datatransfer.Transferable // Required for ImageTransferable
+import java.awt.datatransfer.UnsupportedFlavorException // Required for ImageTransferable
 import java.awt.image.BufferedImage
 import java.io.File
 import java.io.FilenameFilter
 import java.io.IOException
 import java.net.URI
 import javax.imageio.ImageIO
-import kotlin.text.endsWith
-import kotlin.text.lowercase
+
+class ImageTransferable(private val image: Image) : Transferable {
+    override fun getTransferDataFlavors(): Array<DataFlavor> {
+        return arrayOf(DataFlavor.imageFlavor)
+    }
+
+    override fun isDataFlavorSupported(flavor: DataFlavor?): Boolean {
+        return DataFlavor.imageFlavor.equals(flavor)
+    }
+
+    @Throws(UnsupportedFlavorException::class, IOException::class)
+    override fun getTransferData(flavor: DataFlavor?): Any {
+        if (!DataFlavor.imageFlavor.equals(flavor)) {
+            throw UnsupportedFlavorException(flavor)
+        }
+        return image
+    }
+}
 
 class RealLogics(
     val outputVoice: (String, String) -> Unit = { _, _ -> },
@@ -54,7 +75,6 @@ class RealLogics(
     override fun openEmail(emailAddress: String, subject: String, body: String) {
         val desktop = Desktop.getDesktop()
         if (Desktop.isDesktopSupported()) {
-            val desktop = Desktop.getDesktop()
             if (desktop.isSupported(Desktop.Action.MAIL)) {
                 try {
                     val mailtoUri = "mailto:$emailAddress?subject=${
@@ -63,12 +83,10 @@ class RealLogics(
                     desktop.mail(URI(mailtoUri))
                 } catch (e: Exception) {
                     e.printStackTrace()
-                    // Fallback or error handling
                     println("Error opening email client: ${e.message}")
                 }
             } else {
                 println("Desktop.Action.MAIL is not supported.")
-                // You might try opening a mailto: link in the default browser as a fallback
                 try {
                     val mailtoUri = "mailto:$emailAddress?subject=${
                         java.net.URLEncoder.encode(subject, "UTF-8")
@@ -97,11 +115,8 @@ class RealLogics(
     }
 
     override fun chooseImage() {
-        val frame: Frame? = null // Or get your main app Frame if available
-        // Configure FileDialog for loading/opening a file
+        val frame: Frame? = null
         val fileDialog = FileDialog(frame, "Select Image File", FileDialog.LOAD)
-
-        // Optional: Set a filename filter to show only image files
         fileDialog.filenameFilter = FilenameFilter { _, name ->
             val lowercaseName = name.lowercase()
             lowercaseName.endsWith(".png") ||
@@ -110,8 +125,7 @@ class RealLogics(
                 lowercaseName.endsWith(".gif") ||
                 lowercaseName.endsWith(".bmp")
         }
-
-        fileDialog.isVisible = true // Show the dialog (this is blocking)
+        fileDialog.isVisible = true
 
         val directory = fileDialog.directory
         val filename = fileDialog.file
@@ -119,38 +133,36 @@ class RealLogics(
         if (directory != null && filename != null) {
             val selectedFile = File(directory, filename)
             println("Selected file: ${selectedFile.absolutePath}")
-           imageSelectedCallback(selectedFile.absolutePath)
+            imageSelectedCallback(selectedFile.absolutePath)
         } else {
             println("No file selected or dialog cancelled.")
         }
     }
 
     override fun shareNote(notePad: NotePad) {
+        // Not typically implemented for JVM desktop in the same way as mobile
+        println("Share note: $notePad (no standard share sheet on JVM)")
     }
 
     override fun askForNotificationPermission() {
+        // No standard notification permission model like Android/iOS on general JVM
+        onNotification() // Call the callback directly if it represents a general notification action
     }
 
     override fun checkNotificationPermission(): Boolean {
-        onNotification()
-        return false
+        onNotification() // Or however you handle "notifications" in JVM
+        return true // Or false, depending on what this means in your JVM context
     }
 
     override fun shareDrawing(bitmap: ImageBitmap) {
-        // 1. Convert Compose ImageBitmap to AWT BufferedImage
         val bufferedImage: BufferedImage = bitmap.toAwtImage()
-
-        // 2. Show a FileDialog to let the user choose where to save
-        //    Using a Frame as the parent for the FileDialog.
-        //    If your app has a main window (Frame), use that. Otherwise, a temporary Frame.
-        val frame: Frame? = null // Or get your main app Frame if available
+        val frame: Frame? = null
         val fileDialog = FileDialog(frame, "Save Drawing As...", FileDialog.SAVE)
-        fileDialog.file = "drawing.png" // Default filename
+        fileDialog.file = "drawing.png"
         fileDialog.isVisible = true
 
         val selectedFile = fileDialog.directory?.let { dir ->
             fileDialog.file?.let { filename ->
-                // Ensure the filename has a .png extension if the user didn't add one
                 val finalFilename = if (filename.lowercase().endsWith(".png")) filename else "$filename.png"
                 File(dir, finalFilename)
             }
@@ -158,12 +170,9 @@ class RealLogics(
 
         if (selectedFile != null) {
             try {
-                // 3. Save the BufferedImage to the selected file
                 val success = ImageIO.write(bufferedImage, "png", selectedFile)
                 if (success) {
                     println("Drawing saved successfully to: ${selectedFile.absolutePath}")
-
-                    // Optional: Try to open the saved file with the default application
                     if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)) {
                         try {
                             Desktop.getDesktop().open(selectedFile)
@@ -180,10 +189,23 @@ class RealLogics(
             } catch (e: IOException) {
                 println("Error saving drawing: ${e.message}")
                 e.printStackTrace()
-                // You might want to show an error message to the user here
             }
         } else {
             println("Save operation cancelled by the user.")
+        }
+    }
+
+    override fun copyDrawing(bitmap: ImageBitmap) {
+        try {
+            val bufferedImage: BufferedImage = bitmap.toAwtImage()
+            val transferable = ImageTransferable(bufferedImage)
+            val clipboard: Clipboard = Toolkit.getDefaultToolkit().systemClipboard
+            clipboard.setContents(transferable, null)
+            println("Drawing copied to clipboard.")
+        } catch (e: Exception) {
+            println("Error copying drawing to clipboard: ${e.message}")
+            e.printStackTrace()
+            // Optionally, provide feedback to the user that copying failed
         }
     }
 }

--- a/core/ui/src/jvmMain/kotlin/com/mshdabiola/ui/RealLogics.kt
+++ b/core/ui/src/jvmMain/kotlin/com/mshdabiola/ui/RealLogics.kt
@@ -15,10 +15,18 @@
  */
 package com.mshdabiola.ui
 
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toAwtImage
 import com.mohamedrejeb.calf.picker.FilePickerLauncher
 import com.mshdabiola.model.note.NotePad
 import java.awt.Desktop
+import java.awt.FileDialog
+import java.awt.Frame
+import java.awt.image.BufferedImage
+import java.io.File
+import java.io.IOException
 import java.net.URI
+import javax.imageio.ImageIO
 
 class RealLogics(
     val pickerLauncher: FilePickerLauncher,
@@ -97,5 +105,56 @@ class RealLogics(
     override fun checkNotificationPermission(): Boolean {
         onNotification()
         return false
+    }
+
+    override fun shareDrawing(bitmap: ImageBitmap) {
+        // 1. Convert Compose ImageBitmap to AWT BufferedImage
+        val bufferedImage: BufferedImage = bitmap.toAwtImage()
+
+        // 2. Show a FileDialog to let the user choose where to save
+        //    Using a Frame as the parent for the FileDialog.
+        //    If your app has a main window (Frame), use that. Otherwise, a temporary Frame.
+        val frame: Frame? = null // Or get your main app Frame if available
+        val fileDialog = FileDialog(frame, "Save Drawing As...", FileDialog.SAVE)
+        fileDialog.file = "drawing.png" // Default filename
+        fileDialog.isVisible = true
+
+        val selectedFile = fileDialog.directory?.let { dir ->
+            fileDialog.file?.let { filename ->
+                // Ensure the filename has a .png extension if the user didn't add one
+                val finalFilename = if (filename.lowercase().endsWith(".png")) filename else "$filename.png"
+                File(dir, finalFilename)
+            }
+        }
+
+        if (selectedFile != null) {
+            try {
+                // 3. Save the BufferedImage to the selected file
+                val success = ImageIO.write(bufferedImage, "png", selectedFile)
+                if (success) {
+                    println("Drawing saved successfully to: ${selectedFile.absolutePath}")
+
+                    // Optional: Try to open the saved file with the default application
+                    if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.OPEN)) {
+                        try {
+                            Desktop.getDesktop().open(selectedFile)
+                        } catch (e: IOException) {
+                            println("Error opening the saved file: ${e.message}")
+                            e.printStackTrace()
+                        }
+                    } else {
+                        println("Cannot open file: Desktop.Action.OPEN not supported.")
+                    }
+                } else {
+                    println("Failed to save drawing. ImageIO.write returned false.")
+                }
+            } catch (e: IOException) {
+                println("Error saving drawing: ${e.message}")
+                e.printStackTrace()
+                // You might want to show an error message to the user here
+            }
+        } else {
+            println("Save operation cancelled by the user.")
+        }
     }
 }

--- a/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/ChooseImageDialogTest.kt
+++ b/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/ChooseImageDialogTest.kt
@@ -23,9 +23,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
-import com.mohamedrejeb.calf.picker.FilePickerFileType
-import com.mohamedrejeb.calf.picker.FilePickerLauncher
-import com.mohamedrejeb.calf.picker.FilePickerSelectionMode
 import com.mshdabiola.model.note.NotePad
 import com.mshdabiola.model.testtag.ChooseImageDialogTestTags
 import org.junit.Assert.assertEquals
@@ -43,7 +40,7 @@ class ChooseImageDialogTest {
     fun chooseImageDialog_isNotDisplayed_whenShowIsFalse() {
         val realLogics = RealLogics(
             outputVoice = { s1, s2 -> },
-           imageSelectedCallback = {},
+            imageSelectedCallback = {},
             savePhoto = {},
             onNotification = { },
         )
@@ -139,7 +136,7 @@ class ChooseImageDialogTest {
             }
 
             override fun chooseImage() {
-                chosenImageUri=testUri
+                chosenImageUri = testUri
             }
 
             override fun shareNote(notePad: NotePad) {
@@ -152,7 +149,6 @@ class ChooseImageDialogTest {
                 return true
             }
             override fun shareDrawing(bitmap: ImageBitmap) {
-
             }
 
             override fun copyDrawing(bitmap: ImageBitmap) {

--- a/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/ChooseImageDialogTest.kt
+++ b/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/ChooseImageDialogTest.kt
@@ -41,11 +41,7 @@ class ChooseImageDialogTest {
     fun chooseImageDialog_isNotDisplayed_whenShowIsFalse() {
         val realLogics = RealLogics(
             outputVoice = { s1, s2 -> },
-            pickerLauncher = FilePickerLauncher(
-                type = FilePickerFileType.Image,
-                selectionMode = FilePickerSelectionMode.Single,
-                onLaunch = { },
-            ),
+           imageSelectedCallback = {},
             savePhoto = {},
             onNotification = { },
         )
@@ -64,11 +60,7 @@ class ChooseImageDialogTest {
     fun chooseImageDialog_isDisplayed_whenShowIsTrue() {
         val realLogics = RealLogics(
             outputVoice = { s1, s2 -> },
-            pickerLauncher = FilePickerLauncher(
-                type = FilePickerFileType.Image,
-                selectionMode = FilePickerSelectionMode.Single,
-                onLaunch = { },
-            ),
+            imageSelectedCallback = {},
             savePhoto = {},
             onNotification = { },
         )
@@ -94,11 +86,7 @@ class ChooseImageDialogTest {
 
         val realLogics = RealLogics(
             outputVoice = { s1, s2 -> },
-            pickerLauncher = FilePickerLauncher(
-                type = FilePickerFileType.Image,
-                selectionMode = FilePickerSelectionMode.Single,
-                onLaunch = { savedImageUri = testUri },
-            ),
+            imageSelectedCallback = {},
             savePhoto = { savedImageUri = testUri },
             onNotification = { },
         )
@@ -133,11 +121,7 @@ class ChooseImageDialogTest {
 
         val realLogics = RealLogics(
             outputVoice = { s1, s2 -> },
-            pickerLauncher = FilePickerLauncher(
-                type = FilePickerFileType.Image,
-                selectionMode = FilePickerSelectionMode.Single,
-                onLaunch = { chosenImageUri = testUri },
-            ),
+            imageSelectedCallback = {},
             savePhoto = {},
             onNotification = { },
         )
@@ -174,11 +158,7 @@ class ChooseImageDialogTest {
         }
         val realLogics = RealLogics(
             outputVoice = { s1, s2 -> },
-            pickerLauncher = FilePickerLauncher(
-                type = FilePickerFileType.Image,
-                selectionMode = FilePickerSelectionMode.Single,
-                onLaunch = {},
-            ),
+            imageSelectedCallback = {},
             savePhoto = {},
             onNotification = { },
         )

--- a/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/ChooseImageDialogTest.kt
+++ b/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/ChooseImageDialogTest.kt
@@ -18,6 +18,7 @@ package com.mshdabiola.ui
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -25,6 +26,7 @@ import androidx.compose.ui.test.performClick
 import com.mohamedrejeb.calf.picker.FilePickerFileType
 import com.mohamedrejeb.calf.picker.FilePickerLauncher
 import com.mohamedrejeb.calf.picker.FilePickerSelectionMode
+import com.mshdabiola.model.note.NotePad
 import com.mshdabiola.model.testtag.ChooseImageDialogTestTags
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -119,12 +121,43 @@ class ChooseImageDialogTest {
         var chosenImageUri: String? = null
         val testUri = "content://image_uri_for_choose"
 
-        val realLogics = RealLogics(
-            outputVoice = { s1, s2 -> },
-            imageSelectedCallback = {},
-            savePhoto = {},
-            onNotification = { },
-        )
+        val logics = object : Logics {
+            override fun openUrl(url: String) {
+            }
+
+            override fun openEmail(emailAddress: String, subject: String, body: String) {
+            }
+
+            override fun isVoiceAvailable(): Boolean {
+                return true
+            }
+
+            override fun openVoice() {
+            }
+
+            override fun snapImage(path: String) {
+            }
+
+            override fun chooseImage() {
+                chosenImageUri=testUri
+            }
+
+            override fun shareNote(notePad: NotePad) {
+            }
+
+            override fun askForNotificationPermission() {
+            }
+
+            override fun checkNotificationPermission(): Boolean {
+                return true
+            }
+            override fun shareDrawing(bitmap: ImageBitmap) {
+
+            }
+
+            override fun copyDrawing(bitmap: ImageBitmap) {
+            }
+        }
         composeTestRule.setContent {
             if (showDialog) {
                 ChooseImageDialog(
@@ -133,7 +166,7 @@ class ChooseImageDialogTest {
                         dismissCalled = true
                         showDialog = false
                     },
-                    logics = realLogics,
+                    logics = logics,
                     getUri = { testUri },
                 )
             }

--- a/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/OutDrawingTest.kt
+++ b/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/OutDrawingTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Designed and developed by 2024 mshdabiola (lawal abiola)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mshdabiola.ui
 
 import androidx.compose.runtime.mutableStateListOf
@@ -5,7 +20,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.ImageBitmapConfig
 import androidx.compose.ui.graphics.Paint
-import androidx.compose.ui.graphics.StrokeCap // For mapping if needed, though PenProperties uses index
 import androidx.compose.ui.unit.Density
 import com.mshdabiola.model.note.PenProperties
 import com.mshdabiola.model.note.Point
@@ -14,7 +28,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import com.mshdabiola.model.note.Path as DrawingPath // Correct alias
-import androidx.compose.ui.graphics.Path as ComposePath // For creating expected shape paths if OutDrawing constructs them
 
 // Helper extension function to convert Compose Color to ARGB Int
 fun Color.asArgbInt(): Int {
@@ -77,7 +90,10 @@ class OutDrawingTest {
         assertNotNull(resultBitmap)
         assertEquals(originalBitmap.width, resultBitmap.width)
         assertEquals(originalBitmap.height, resultBitmap.height)
-        assertTrue(isBitmapUniformColor(resultBitmap, originalColor), "Bitmap content should be uniformly the original color when no paths are drawn.")
+        assertTrue(
+            isBitmapUniformColor(resultBitmap, originalColor),
+            "Bitmap content should be uniformly the original color when no paths are drawn.",
+        )
     }
 
     @Test
@@ -89,16 +105,19 @@ class OutDrawingTest {
                 penProperties = PenProperties(
                     isPen = true,
                     lineWidth = 2,
-                    colorIndex = 0 // Assuming index 0 maps to a visible color like Black in OutDrawing.kt
-                )
-            )
+                    colorIndex = 0, // Assuming index 0 maps to a visible color like Black in OutDrawing.kt
+                ),
+            ),
         )
         val density = Density(1f)
 
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
         assertNotNull(resultBitmap)
-        assertTrue(bitmapsAreDifferent(originalBitmap, resultBitmap), "Bitmap content should be different after drawing a pen path.")
+        assertTrue(
+            bitmapsAreDifferent(originalBitmap, resultBitmap),
+            "Bitmap content should be different after drawing a pen path.",
+        )
     }
 
     @Test
@@ -106,16 +125,25 @@ class OutDrawingTest {
         val originalBitmap = createTestBitmap(color = Color.White)
         val pathsToDraw = listOf(
             DrawingPath(
-                points = mutableStateListOf(Point(20f, 20f), Point(80f, 20f), Point(80f, 80f), Point(20f, 20f)), // Triangle
-                penProperties = PenProperties(isPen = false) // color/stroke for shapes would be default in OutDrawing.kt
-            )
+                points = mutableStateListOf(
+                    Point(20f, 20f),
+                    Point(80f, 20f),
+                    Point(80f, 80f),
+                    Point(20f, 20f),
+                ), // Triangle
+                penProperties = PenProperties(isPen = false),
+                // color/stroke for shapes would be default in OutDrawing.kt
+            ),
         )
         val density = Density(1f)
 
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
         assertNotNull(resultBitmap)
-        assertTrue(bitmapsAreDifferent(originalBitmap, resultBitmap), "Bitmap content should be different after drawing a shape.")
+        assertTrue(
+            bitmapsAreDifferent(originalBitmap, resultBitmap),
+            "Bitmap content should be different after drawing a shape.",
+        )
     }
 
     @Test
@@ -126,16 +154,19 @@ class OutDrawingTest {
                 points = mutableStateListOf(Point(1000f, 1000f), Point(1500f, 1500f)),
                 penProperties = PenProperties(
                     isPen = true,
-                    lineWidth = 5 // Original large stroke width from PenProperties
-                )
-            )
+                    lineWidth = 5, // Original large stroke width from PenProperties
+                ),
+            ),
         )
         val density = Density(1f)
 
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
         assertNotNull(resultBitmap)
-        assertTrue(bitmapsAreDifferent(originalBitmap, resultBitmap), "Bitmap should change due to scaling of out-of-bounds path.")
+        assertTrue(
+            bitmapsAreDifferent(originalBitmap, resultBitmap),
+            "Bitmap should change due to scaling of out-of-bounds path.",
+        )
     }
 
     @Test
@@ -147,12 +178,15 @@ class OutDrawingTest {
         val pathsToDraw = listOf(
             DrawingPath(
                 points = mutableStateListOf(Point(10f, 10f)), // Single point
-                penProperties = PenProperties(isPen = true, lineWidth = 2)
-            )
+                penProperties = PenProperties(isPen = true, lineWidth = 2),
+            ),
         )
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
-        assertTrue(bitmapsAreSame(baselineBitmap, resultBitmap),"Bitmap should be unchanged for a single-point pen path.")
+        assertTrue(
+            bitmapsAreSame(baselineBitmap, resultBitmap),
+            "Bitmap should be unchanged for a single-point pen path.",
+        )
     }
 
     @Test
@@ -164,12 +198,15 @@ class OutDrawingTest {
         val pathsToDraw = listOf(
             DrawingPath(
                 points = mutableStateListOf(), // Empty points list
-                penProperties = PenProperties(isPen = false)
-            )
+                penProperties = PenProperties(isPen = false),
+            ),
         )
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
-        assertTrue(bitmapsAreSame(baselineBitmap, resultBitmap), "Bitmap should be unchanged for a non-pen path with empty points.")
+        assertTrue(
+            bitmapsAreSame(baselineBitmap, resultBitmap),
+            "Bitmap should be unchanged for a non-pen path with empty points.",
+        )
     }
 
     @Test
@@ -180,13 +217,17 @@ class OutDrawingTest {
 
         val pathsToDraw = listOf(
             DrawingPath(
-                points = mutableStateListOf(Point(10f, 10f), Point(10f, 50f)), // Vertical line, zero drawing width for points themselves
-                penProperties = PenProperties(isPen = true, lineWidth = 1)
-            )
+                points = mutableStateListOf(Point(10f, 10f), Point(10f, 50f)),
+                // Vertical line, zero drawing width for points themselves
+                penProperties = PenProperties(isPen = true, lineWidth = 1),
+            ),
         )
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
-        assertTrue(bitmapsAreSame(baselineBitmap, resultBitmap), "Bitmap should be unchanged if drawing area of points has zero width.")
+        assertTrue(
+            bitmapsAreSame(baselineBitmap, resultBitmap),
+            "Bitmap should be unchanged if drawing area of points has zero width.",
+        )
     }
 
     @Test
@@ -197,13 +238,17 @@ class OutDrawingTest {
 
         val pathsToDraw = listOf(
             DrawingPath(
-                points = mutableStateListOf(Point(10f, 10f), Point(50f, 10f)), // Horizontal line, zero drawing height for points
-                penProperties = PenProperties(isPen = true, lineWidth = 1)
-            )
+                points = mutableStateListOf(Point(10f, 10f), Point(50f, 10f)),
+                // Horizontal line, zero drawing height for points
+                penProperties = PenProperties(isPen = true, lineWidth = 1),
+            ),
         )
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
-        assertTrue(bitmapsAreSame(baselineBitmap, resultBitmap), "Bitmap should be unchanged if drawing area of points has zero height.")
+        assertTrue(
+            bitmapsAreSame(baselineBitmap, resultBitmap),
+            "Bitmap should be unchanged if drawing area of points has zero height.",
+        )
     }
 
     @Test
@@ -215,15 +260,18 @@ class OutDrawingTest {
         val pathsToDraw = listOf(
             DrawingPath(
                 points = mutableStateListOf(),
-                penProperties = PenProperties(isPen = true)
+                penProperties = PenProperties(isPen = true),
             ),
             DrawingPath(
                 points = mutableStateListOf(),
-                penProperties = PenProperties(isPen = false)
-            )
+                penProperties = PenProperties(isPen = false),
+            ),
         )
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
-        assertTrue(bitmapsAreSame(baselineBitmap, resultBitmap), "Bitmap should be unchanged if all paths have no valid drawing points.")
+        assertTrue(
+            bitmapsAreSame(baselineBitmap, resultBitmap),
+            "Bitmap should be unchanged if all paths have no valid drawing points.",
+        )
     }
 }

--- a/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/OutDrawingTest.kt
+++ b/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/OutDrawingTest.kt
@@ -1,9 +1,11 @@
 package com.mshdabiola.ui
 
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.ImageBitmapConfig
 import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.StrokeCap // For mapping if needed, though PenProperties uses index
 import androidx.compose.ui.unit.Density
 import com.mshdabiola.model.note.PenProperties
 import com.mshdabiola.model.note.Point
@@ -11,8 +13,17 @@ import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import androidx.compose.ui.graphics.Path as ComposePath
-import com.mshdabiola.model.note.Path as DrawingPath
+import com.mshdabiola.model.note.Path as DrawingPath // Correct alias
+import androidx.compose.ui.graphics.Path as ComposePath // For creating expected shape paths if OutDrawing constructs them
+
+// Helper extension function to convert Compose Color to ARGB Int
+fun Color.asArgbInt(): Int {
+    val alpha = (this.alpha * 255.0f + 0.5f).toInt()
+    val red = (this.red * 255.0f + 0.5f).toInt()
+    val green = (this.green * 255.0f + 0.5f).toInt()
+    val blue = (this.blue * 255.0f + 0.5f).toInt()
+    return (alpha shl 24) or (red shl 16) or (green shl 8) or blue
+}
 
 class OutDrawingTest {
 
@@ -46,9 +57,18 @@ class OutDrawingTest {
         return buffer1.contentEquals(buffer2)
     }
 
+    private fun isBitmapUniformColor(bitmap: ImageBitmap, expectedColor: Color): Boolean {
+        val buffer = IntArray(bitmap.width * bitmap.height)
+        bitmap.readPixels(buffer, 0, 0, bitmap.width, bitmap.height)
+        val expectedPixel = expectedColor.asArgbInt()
+        if (buffer.isEmpty() && (bitmap.width > 0 || bitmap.height > 0)) return false
+        return buffer.all { it == expectedPixel }
+    }
+
     @Test
-    fun `drawPathsOnImage with empty paths returns original-like bitmap`() {
-        val originalBitmap = createTestBitmap()
+    fun `drawPathsOnImage with empty paths results in bitmap reflecting original color`() {
+        val originalColor = Color.Yellow
+        val originalBitmap = createTestBitmap(color = originalColor)
         val pathsToDraw = emptyList<DrawingPath>()
         val density = Density(1f)
 
@@ -57,7 +77,7 @@ class OutDrawingTest {
         assertNotNull(resultBitmap)
         assertEquals(originalBitmap.width, resultBitmap.width)
         assertEquals(originalBitmap.height, resultBitmap.height)
-        assertTrue(bitmapsAreSame(originalBitmap, resultBitmap), "Bitmap content should be the same when no paths are drawn.")
+        assertTrue(isBitmapUniformColor(resultBitmap, originalColor), "Bitmap content should be uniformly the original color when no paths are drawn.")
     }
 
     @Test
@@ -65,50 +85,36 @@ class OutDrawingTest {
         val originalBitmap = createTestBitmap(color = Color.White)
         val pathsToDraw = listOf(
             DrawingPath(
-                points = listOf(Point(10f, 10f), Point(100f, 100f)),
-                penProperties = PenProperties(isPen = false),
-            ),
-            DrawingPath(
-                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
-                penProperties = PenProperties(isPen = true), // Example of a pen stroke
-            ),
+                points = mutableStateListOf(Point(10f, 10f), Point(50f, 50f)),
+                penProperties = PenProperties(
+                    isPen = true,
+                    lineWidth = 2,
+                    colorIndex = 0 // Assuming index 0 maps to a visible color like Black in OutDrawing.kt
+                )
+            )
         )
         val density = Density(1f)
 
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
         assertNotNull(resultBitmap)
-        assertEquals(originalBitmap.width, resultBitmap.width)
-        assertEquals(originalBitmap.height, resultBitmap.height)
-        assertTrue(bitmapsAreDifferent(originalBitmap, resultBitmap), "Bitmap content should be different after drawing.")
+        assertTrue(bitmapsAreDifferent(originalBitmap, resultBitmap), "Bitmap content should be different after drawing a pen path.")
     }
 
     @Test
     fun `drawPathsOnImage with simple shape path draws on bitmap`() {
         val originalBitmap = createTestBitmap(color = Color.White)
-        val composePath = ComposePath().apply {
-            moveTo(20f, 20f)
-            lineTo(80f, 20f)
-            lineTo(80f, 80f)
-            close()
-        }
         val pathsToDraw = listOf(
             DrawingPath(
-                points = listOf(Point(10f, 10f), Point(100f, 100f)),
-                penProperties = PenProperties(isPen = false),
-            ),
-            DrawingPath(
-                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
-                penProperties = PenProperties(isPen = true), // Example of a pen stroke
-            ),
+                points = mutableStateListOf(Point(20f, 20f), Point(80f, 20f), Point(80f, 80f), Point(20f, 20f)), // Triangle
+                penProperties = PenProperties(isPen = false) // color/stroke for shapes would be default in OutDrawing.kt
+            )
         )
         val density = Density(1f)
 
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
         assertNotNull(resultBitmap)
-        assertEquals(originalBitmap.width, resultBitmap.width)
-        assertEquals(originalBitmap.height, resultBitmap.height)
         assertTrue(bitmapsAreDifferent(originalBitmap, resultBitmap), "Bitmap content should be different after drawing a shape.")
     }
 
@@ -117,138 +123,107 @@ class OutDrawingTest {
         val originalBitmap = createTestBitmap(width = 100, height = 100, color = Color.White)
         val pathsToDraw = listOf(
             DrawingPath(
-                points = listOf(Point(10f, 10f), Point(100f, 100f)),
-                penProperties = PenProperties(isPen = false),
-            ),
-            DrawingPath(
-                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
-                penProperties = PenProperties(isPen = true), // Example of a pen stroke
-            ),
+                points = mutableStateListOf(Point(1000f, 1000f), Point(1500f, 1500f)),
+                penProperties = PenProperties(
+                    isPen = true,
+                    lineWidth = 5 // Original large stroke width from PenProperties
+                )
+            )
         )
         val density = Density(1f)
 
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
         assertNotNull(resultBitmap)
-        assertEquals(originalBitmap.width, resultBitmap.width)
-        assertEquals(originalBitmap.height, resultBitmap.height)
-        assertTrue(bitmapsAreDifferent(originalBitmap, resultBitmap), "Bitmap should change even if paths are initially out of bounds due to scaling.")
+        assertTrue(bitmapsAreDifferent(originalBitmap, resultBitmap), "Bitmap should change due to scaling of out-of-bounds path.")
     }
 
     @Test
-    fun `drawPathsOnImage with pen path with one point does not draw`() {
+    fun `drawPathsOnImage with pen path with one point does not alter bitmap from initial copy`() {
         val originalBitmap = createTestBitmap(color = Color.White)
+        val density = Density(1f)
+        val baselineBitmap = drawPathsOnImage(originalBitmap, emptyList(), density)
+
         val pathsToDraw = listOf(
             DrawingPath(
-                points = listOf(Point(10f, 10f), Point(100f, 100f)),
-                penProperties = PenProperties(isPen = false),
-            ),
-            DrawingPath(
-                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
-                penProperties = PenProperties(isPen = true), // Example of a pen stroke
-            ),
+                points = mutableStateListOf(Point(10f, 10f)), // Single point
+                penProperties = PenProperties(isPen = true, lineWidth = 2)
+            )
         )
-        val density = Density(1f)
-
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
-        assertNotNull(resultBitmap)
-        assertEquals(originalBitmap.width, resultBitmap.width)
-        assertEquals(originalBitmap.height, resultBitmap.height)
-        assertTrue(bitmapsAreSame(originalBitmap, resultBitmap),"Bitmap should be unchanged for a single-point pen path as the drawing loop requires >1 points.")
+        assertTrue(bitmapsAreSame(baselineBitmap, resultBitmap),"Bitmap should be unchanged for a single-point pen path.")
     }
 
     @Test
-    fun `drawPathsOnImage with empty non-pen path does not draw`() {
+    fun `drawPathsOnImage with empty points non-pen path does not alter bitmap`() {
         val originalBitmap = createTestBitmap(color = Color.White)
+        val density = Density(1f)
+        val baselineBitmap = drawPathsOnImage(originalBitmap, emptyList(), density)
+
         val pathsToDraw = listOf(
             DrawingPath(
-                points = listOf(Point(10f, 10f), Point(100f, 100f)),
-                penProperties = PenProperties(isPen = false),
-            ),
-            DrawingPath(
-                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
-                penProperties = PenProperties(isPen = true), // Example of a pen stroke
-            ),
+                points = mutableStateListOf(), // Empty points list
+                penProperties = PenProperties(isPen = false)
+            )
         )
-        val density = Density(1f)
-
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
-        assertNotNull(resultBitmap)
-        assertEquals(originalBitmap.width, resultBitmap.width)
-        assertEquals(originalBitmap.height, resultBitmap.height)
-        assertTrue(bitmapsAreSame(originalBitmap, resultBitmap), "Bitmap should be unchanged for an empty non-pen path.")
+        assertTrue(bitmapsAreSame(baselineBitmap, resultBitmap), "Bitmap should be unchanged for a non-pen path with empty points.")
     }
 
     @Test
-    fun `drawPathsOnImage with zero drawing width returns original-like bitmap`() {
+    fun `drawPathsOnImage with zero drawing width returns bitmap like initial copy`() {
         val originalBitmap = createTestBitmap()
+        val density = Density(1f)
+        val baselineBitmap = drawPathsOnImage(originalBitmap, emptyList(), density)
+
         val pathsToDraw = listOf(
             DrawingPath(
-                points = listOf(Point(10f, 10f), Point(100f, 100f)),
-                penProperties = PenProperties(isPen = false),
-            ),
-            DrawingPath(
-                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
-                penProperties = PenProperties(isPen = true), // Example of a pen stroke
-            ),
+                points = mutableStateListOf(Point(10f, 10f), Point(10f, 50f)), // Vertical line, zero drawing width for points themselves
+                penProperties = PenProperties(isPen = true, lineWidth = 1)
+            )
         )
-        val density = Density(1f)
-
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
-        assertNotNull(resultBitmap)
-        assertEquals(originalBitmap.width, resultBitmap.width)
-        assertEquals(originalBitmap.height, resultBitmap.height)
-        assertTrue(bitmapsAreSame(originalBitmap, resultBitmap), "Bitmap should be unchanged if drawing area has zero width.")
+        assertTrue(bitmapsAreSame(baselineBitmap, resultBitmap), "Bitmap should be unchanged if drawing area of points has zero width.")
     }
 
     @Test
-    fun `drawPathsOnImage with zero drawing height returns original-like bitmap`() {
+    fun `drawPathsOnImage with zero drawing height returns bitmap like initial copy`() {
         val originalBitmap = createTestBitmap()
+        val density = Density(1f)
+        val baselineBitmap = drawPathsOnImage(originalBitmap, emptyList(), density)
+
         val pathsToDraw = listOf(
             DrawingPath(
-                points = listOf(Point(10f, 10f), Point(100f, 100f)),
-                penProperties = PenProperties(isPen = false),
-            ),
-            DrawingPath(
-                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
-                penProperties = PenProperties(isPen = true), // Example of a pen stroke
-            ),
+                points = mutableStateListOf(Point(10f, 10f), Point(50f, 10f)), // Horizontal line, zero drawing height for points
+                penProperties = PenProperties(isPen = true, lineWidth = 1)
+            )
         )
-        val density = Density(1f)
-
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
-        assertNotNull(resultBitmap)
-        assertEquals(originalBitmap.width, resultBitmap.width)
-        assertEquals(originalBitmap.height, resultBitmap.height)
-        assertTrue(bitmapsAreSame(originalBitmap, resultBitmap), "Bitmap should be unchanged if drawing area has zero height.")
+        assertTrue(bitmapsAreSame(baselineBitmap, resultBitmap), "Bitmap should be unchanged if drawing area of points has zero height.")
     }
 
     @Test
-    fun `drawPathsOnImage with no valid points returns original-like bitmap`() {
+    fun `drawPathsOnImage with no valid points in any path returns bitmap like initial copy`() {
         val originalBitmap = createTestBitmap()
-        // Paths that won't contribute to min/max calculations in a meaningful way
-        // or DrawingPath.path.isEmpty is true for non-pen
+        val density = Density(1f)
+        val baselineBitmap = drawPathsOnImage(originalBitmap, emptyList(), density)
+
         val pathsToDraw = listOf(
             DrawingPath(
-                points = listOf(Point(10f, 10f), Point(100f, 100f)),
-                penProperties = PenProperties(isPen = false),
+                points = mutableStateListOf(),
+                penProperties = PenProperties(isPen = true)
             ),
             DrawingPath(
-                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
-                penProperties = PenProperties(isPen = true), // Example of a pen stroke
-            ),
+                points = mutableStateListOf(),
+                penProperties = PenProperties(isPen = false)
+            )
         )
-        val density = Density(1f)
-
         val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
 
-        assertNotNull(resultBitmap)
-        assertEquals(originalBitmap.width, resultBitmap.width)
-        assertEquals(originalBitmap.height, resultBitmap.height)
-        assertTrue(bitmapsAreSame(originalBitmap, resultBitmap), "Bitmap should be unchanged if no valid drawing points are found.")
+        assertTrue(bitmapsAreSame(baselineBitmap, resultBitmap), "Bitmap should be unchanged if all paths have no valid drawing points.")
     }
 }

--- a/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/OutDrawingTest.kt
+++ b/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/OutDrawingTest.kt
@@ -1,0 +1,254 @@
+package com.mshdabiola.ui
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.ImageBitmapConfig
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.unit.Density
+import com.mshdabiola.model.note.PenProperties
+import com.mshdabiola.model.note.Point
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import androidx.compose.ui.graphics.Path as ComposePath
+import com.mshdabiola.model.note.Path as DrawingPath
+
+class OutDrawingTest {
+
+    private fun createTestBitmap(width: Int = 100, height: Int = 100, color: Color = Color.White): ImageBitmap {
+        val bitmap = ImageBitmap(width, height, ImageBitmapConfig.Argb8888)
+        val canvas = androidx.compose.ui.graphics.Canvas(bitmap)
+        val paint = Paint().apply { this.color = color }
+        canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), paint)
+        return bitmap
+    }
+
+    private fun bitmapsAreDifferent(bitmap1: ImageBitmap, bitmap2: ImageBitmap): Boolean {
+        if (bitmap1.width != bitmap2.width || bitmap1.height != bitmap2.height) {
+            return true
+        }
+        val buffer1 = IntArray(bitmap1.width * bitmap1.height)
+        bitmap1.readPixels(buffer1, 0, 0, bitmap1.width, bitmap1.height)
+        val buffer2 = IntArray(bitmap2.width * bitmap2.height)
+        bitmap2.readPixels(buffer2, 0, 0, bitmap2.width, bitmap2.height)
+        return !buffer1.contentEquals(buffer2)
+    }
+
+    private fun bitmapsAreSame(bitmap1: ImageBitmap, bitmap2: ImageBitmap): Boolean {
+        if (bitmap1.width != bitmap2.width || bitmap1.height != bitmap2.height) {
+            return false
+        }
+        val buffer1 = IntArray(bitmap1.width * bitmap1.height)
+        bitmap1.readPixels(buffer1, 0, 0, bitmap1.width, bitmap1.height)
+        val buffer2 = IntArray(bitmap2.width * bitmap2.height)
+        bitmap2.readPixels(buffer2, 0, 0, bitmap2.width, bitmap2.height)
+        return buffer1.contentEquals(buffer2)
+    }
+
+    @Test
+    fun `drawPathsOnImage with empty paths returns original-like bitmap`() {
+        val originalBitmap = createTestBitmap()
+        val pathsToDraw = emptyList<DrawingPath>()
+        val density = Density(1f)
+
+        val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
+
+        assertNotNull(resultBitmap)
+        assertEquals(originalBitmap.width, resultBitmap.width)
+        assertEquals(originalBitmap.height, resultBitmap.height)
+        assertTrue(bitmapsAreSame(originalBitmap, resultBitmap), "Bitmap content should be the same when no paths are drawn.")
+    }
+
+    @Test
+    fun `drawPathsOnImage with simple pen path draws on bitmap`() {
+        val originalBitmap = createTestBitmap(color = Color.White)
+        val pathsToDraw = listOf(
+            DrawingPath(
+                points = listOf(Point(10f, 10f), Point(100f, 100f)),
+                penProperties = PenProperties(isPen = false),
+            ),
+            DrawingPath(
+                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
+                penProperties = PenProperties(isPen = true), // Example of a pen stroke
+            ),
+        )
+        val density = Density(1f)
+
+        val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
+
+        assertNotNull(resultBitmap)
+        assertEquals(originalBitmap.width, resultBitmap.width)
+        assertEquals(originalBitmap.height, resultBitmap.height)
+        assertTrue(bitmapsAreDifferent(originalBitmap, resultBitmap), "Bitmap content should be different after drawing.")
+    }
+
+    @Test
+    fun `drawPathsOnImage with simple shape path draws on bitmap`() {
+        val originalBitmap = createTestBitmap(color = Color.White)
+        val composePath = ComposePath().apply {
+            moveTo(20f, 20f)
+            lineTo(80f, 20f)
+            lineTo(80f, 80f)
+            close()
+        }
+        val pathsToDraw = listOf(
+            DrawingPath(
+                points = listOf(Point(10f, 10f), Point(100f, 100f)),
+                penProperties = PenProperties(isPen = false),
+            ),
+            DrawingPath(
+                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
+                penProperties = PenProperties(isPen = true), // Example of a pen stroke
+            ),
+        )
+        val density = Density(1f)
+
+        val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
+
+        assertNotNull(resultBitmap)
+        assertEquals(originalBitmap.width, resultBitmap.width)
+        assertEquals(originalBitmap.height, resultBitmap.height)
+        assertTrue(bitmapsAreDifferent(originalBitmap, resultBitmap), "Bitmap content should be different after drawing a shape.")
+    }
+
+    @Test
+    fun `drawPathsOnImage handles paths outside bounds with scaling and translation`() {
+        val originalBitmap = createTestBitmap(width = 100, height = 100, color = Color.White)
+        val pathsToDraw = listOf(
+            DrawingPath(
+                points = listOf(Point(10f, 10f), Point(100f, 100f)),
+                penProperties = PenProperties(isPen = false),
+            ),
+            DrawingPath(
+                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
+                penProperties = PenProperties(isPen = true), // Example of a pen stroke
+            ),
+        )
+        val density = Density(1f)
+
+        val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
+
+        assertNotNull(resultBitmap)
+        assertEquals(originalBitmap.width, resultBitmap.width)
+        assertEquals(originalBitmap.height, resultBitmap.height)
+        assertTrue(bitmapsAreDifferent(originalBitmap, resultBitmap), "Bitmap should change even if paths are initially out of bounds due to scaling.")
+    }
+
+    @Test
+    fun `drawPathsOnImage with pen path with one point does not draw`() {
+        val originalBitmap = createTestBitmap(color = Color.White)
+        val pathsToDraw = listOf(
+            DrawingPath(
+                points = listOf(Point(10f, 10f), Point(100f, 100f)),
+                penProperties = PenProperties(isPen = false),
+            ),
+            DrawingPath(
+                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
+                penProperties = PenProperties(isPen = true), // Example of a pen stroke
+            ),
+        )
+        val density = Density(1f)
+
+        val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
+
+        assertNotNull(resultBitmap)
+        assertEquals(originalBitmap.width, resultBitmap.width)
+        assertEquals(originalBitmap.height, resultBitmap.height)
+        assertTrue(bitmapsAreSame(originalBitmap, resultBitmap),"Bitmap should be unchanged for a single-point pen path as the drawing loop requires >1 points.")
+    }
+
+    @Test
+    fun `drawPathsOnImage with empty non-pen path does not draw`() {
+        val originalBitmap = createTestBitmap(color = Color.White)
+        val pathsToDraw = listOf(
+            DrawingPath(
+                points = listOf(Point(10f, 10f), Point(100f, 100f)),
+                penProperties = PenProperties(isPen = false),
+            ),
+            DrawingPath(
+                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
+                penProperties = PenProperties(isPen = true), // Example of a pen stroke
+            ),
+        )
+        val density = Density(1f)
+
+        val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
+
+        assertNotNull(resultBitmap)
+        assertEquals(originalBitmap.width, resultBitmap.width)
+        assertEquals(originalBitmap.height, resultBitmap.height)
+        assertTrue(bitmapsAreSame(originalBitmap, resultBitmap), "Bitmap should be unchanged for an empty non-pen path.")
+    }
+
+    @Test
+    fun `drawPathsOnImage with zero drawing width returns original-like bitmap`() {
+        val originalBitmap = createTestBitmap()
+        val pathsToDraw = listOf(
+            DrawingPath(
+                points = listOf(Point(10f, 10f), Point(100f, 100f)),
+                penProperties = PenProperties(isPen = false),
+            ),
+            DrawingPath(
+                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
+                penProperties = PenProperties(isPen = true), // Example of a pen stroke
+            ),
+        )
+        val density = Density(1f)
+
+        val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
+
+        assertNotNull(resultBitmap)
+        assertEquals(originalBitmap.width, resultBitmap.width)
+        assertEquals(originalBitmap.height, resultBitmap.height)
+        assertTrue(bitmapsAreSame(originalBitmap, resultBitmap), "Bitmap should be unchanged if drawing area has zero width.")
+    }
+
+    @Test
+    fun `drawPathsOnImage with zero drawing height returns original-like bitmap`() {
+        val originalBitmap = createTestBitmap()
+        val pathsToDraw = listOf(
+            DrawingPath(
+                points = listOf(Point(10f, 10f), Point(100f, 100f)),
+                penProperties = PenProperties(isPen = false),
+            ),
+            DrawingPath(
+                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
+                penProperties = PenProperties(isPen = true), // Example of a pen stroke
+            ),
+        )
+        val density = Density(1f)
+
+        val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
+
+        assertNotNull(resultBitmap)
+        assertEquals(originalBitmap.width, resultBitmap.width)
+        assertEquals(originalBitmap.height, resultBitmap.height)
+        assertTrue(bitmapsAreSame(originalBitmap, resultBitmap), "Bitmap should be unchanged if drawing area has zero height.")
+    }
+
+    @Test
+    fun `drawPathsOnImage with no valid points returns original-like bitmap`() {
+        val originalBitmap = createTestBitmap()
+        // Paths that won't contribute to min/max calculations in a meaningful way
+        // or DrawingPath.path.isEmpty is true for non-pen
+        val pathsToDraw = listOf(
+            DrawingPath(
+                points = listOf(Point(10f, 10f), Point(100f, 100f)),
+                penProperties = PenProperties(isPen = false),
+            ),
+            DrawingPath(
+                points = listOf(Point(50f, 50f), Point(150f, 50f), Point(150f, 150f)),
+                penProperties = PenProperties(isPen = true), // Example of a pen stroke
+            ),
+        )
+        val density = Density(1f)
+
+        val resultBitmap = drawPathsOnImage(originalBitmap, pathsToDraw, density)
+
+        assertNotNull(resultBitmap)
+        assertEquals(originalBitmap.width, resultBitmap.width)
+        assertEquals(originalBitmap.height, resultBitmap.height)
+        assertTrue(bitmapsAreSame(originalBitmap, resultBitmap), "Bitmap should be unchanged if no valid drawing points are found.")
+    }
+}

--- a/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/RealLogicsTest.kt
+++ b/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/RealLogicsTest.kt
@@ -1,7 +1,6 @@
 /*
  * Designed and developed by 2024 mshdabiola (lawal abiola)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -15,94 +14,69 @@
  */
 package com.mshdabiola.ui
 
-import com.mohamedrejeb.calf.picker.FilePickerFileType
-import com.mohamedrejeb.calf.picker.FilePickerLauncher
-import com.mohamedrejeb.calf.picker.FilePickerSelectionMode
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Paint
 import com.mshdabiola.model.note.NotePad
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
+import org.junit.Assume
 import org.junit.Before
 import org.junit.Test
+import java.awt.HeadlessException
+import java.awt.Toolkit
+import java.awt.datatransfer.DataFlavor
+import java.awt.image.BufferedImage
 
 class RealLogicsTest {
 
     private var outputVoiceCalledWith: Pair<String, String>? = null
-    private var saveImageCalledWith: String? = null
-    private var savePhotoCalled = false
+    private var saveImageCalledWith: String? = null // For chooseImage
+    private var savePhotoCalled = false // For snapImage
     private var onNotificationCalled = false
+    private var imageSelectedPath: String? = null // For imageSelectedCallback
 
     private lateinit var realLogics: RealLogics
 
+    // Helper to create a simple ImageBitmap for testing
+    private fun createTestImageBitmap(width: Int = 10, height: Int = 10, color: Color = Color.Red): ImageBitmap {
+        val imageBitmap = ImageBitmap(width, height)
+        val canvas = Canvas(imageBitmap)
+        val paint = Paint().apply { this.color = color }
+        canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), paint)
+        return imageBitmap
+    }
+
     @Before
     fun setUp() {
+        // Skip clipboard tests in headless environments where AWT might not be fully available
+        try {
+            Toolkit.getDefaultToolkit().systemClipboard
+        } catch (e: HeadlessException) {
+            Assume.assumeNoException("Skipping clipboard tests in headless environment", e)
+        }
+
         outputVoiceCalledWith = null
         saveImageCalledWith = null
         savePhotoCalled = false
         onNotificationCalled = false
+        imageSelectedPath = null
 
         realLogics = RealLogics(
             outputVoice = { s1, s2 -> outputVoiceCalledWith = s1 to s2 },
-            pickerLauncher = FilePickerLauncher(
-                type = FilePickerFileType.Image,
-                selectionMode = FilePickerSelectionMode.Single,
-                onLaunch = { saveImageCalledWith = "test/image/path.jpg" },
-            ),
-            savePhoto = { savePhotoCalled = true },
+            // For chooseImage, the pickerLauncher's onLaunch is not directly testable here
+            // for its actual file picking logic without significant mocking or integration setup.
+            // We test the imageSelectedCallback instead.
+            savePhoto = { savePhotoCalled = true }, // For snapImage
             onNotification = { onNotificationCalled = true },
+            imageSelectedCallback = { path -> imageSelectedPath = path } // For chooseImage
         )
     }
-//
-//    @Test
-//    fun `openUrl with valid URL does not crash`() {
-//        // This test mainly ensures that URI creation and Desktop.getDesktop() don't throw an unexpected error.
-//        // Verifying actual browser opening is beyond a simple unit test.
-//        // We rely on the fact that if Desktop is not supported, it will print to console.
-//        try {
-//            realLogics.openUrl("https://www.example.com")
-//            // No assertion needed if it doesn't crash
-//        } catch (e: Exception) {
-//            fail("openUrl with valid URL should not throw an exception: ${e.message}")
-//        }
-//    }
-//
-//    @Test
-//    fun `openUrl with invalid URL is handled gracefully`() {
-//        // Example of an invalid URI that would throw URISyntaxException
-//        try {
-//            realLogics.openUrl("htp://www.example.com")
-//            // The method catches Exception and prints stack trace, so no crash is expected.
-//        } catch (e: Exception) {
-//            fail("openUrl with invalid URL should be handled by the catch block: ${e.message}")
-//        }
-//    }
-//
-//    @Test
-//    fun `openEmail with valid parameters does not crash`() {
-//        // Similar to openUrl, this checks URI creation, encoding, and Desktop interaction.
-//        try {
-//            realLogics.openEmail("test@example.com", "Test Subject", "Test Body")
-//            // No assertion needed if it doesn't crash
-//        } catch (e: Exception) {
-//            fail("openEmail with valid parameters should not throw an exception: ${e.message}")
-//        }
-//    }
-//
-//    @Test
-//    fun `openEmail encodes subject and body`() {
-//        // We can't directly check the URI passed to Desktop.mail,
-//        // but we can infer the encoding by checking if specific characters would cause issues if not encoded.
-//        // This is an indirect way to test the URLEncoder part.
-//         try {
-//            realLogics.openEmail("test@example.com", "Subject with spaces & symbols!", "Body with / and ?")
-//            // If it reaches here without URI syntax issues due to unencoded characters, it's a good sign.
-//        } catch (e: Exception) {
-//            fail("openEmail with special characters in subject/body should not throw an exception: ${e.message}")
-//        }
-//    }
-//
 
     @Test
     fun `isVoiceAvailable returns false`() {
@@ -124,12 +98,16 @@ class RealLogicsTest {
     }
 
     @Test
-    fun `chooseImage calls saveImage lambda with path`() {
-        assertNull(saveImageCalledWith)
+    fun `chooseImage - invoking selection via callback`() {
+        // This test simulates the callback that would occur after a file is chosen.
+        // The actual FileDialog interaction is not tested here.
+        assertNull(imageSelectedPath)
         val testPath = "test/image/path.jpg"
-        realLogics.chooseImage()
-        assertEquals(testPath, saveImageCalledWith)
+        // Simulate the FileDialog closing and calling the callback
+        realLogics.imageSelectedCallback(testPath)
+        assertEquals(testPath, imageSelectedPath)
     }
+
 
     @Test
     fun `shareNote executes without error`() {
@@ -142,20 +120,87 @@ class RealLogicsTest {
     }
 
     @Test
-    fun `askForNotificationPermission executes without error`() {
+    fun `askForNotificationPermission calls onNotification lambda`() {
+        assertFalse(onNotificationCalled)
+        realLogics.askForNotificationPermission()
+        assertTrue(onNotificationCalled)
+    }
+
+    @Test
+    fun `checkNotificationPermission calls onNotification lambda and returns true`() {
+        // As per current jvmMain RealLogics, it calls onNotification and returns true
+        assertFalse(onNotificationCalled)
+        val result = realLogics.checkNotificationPermission()
+        assertTrue(onNotificationCalled)
+        assertTrue(result) // Updated assertion based on jvmMain implementation
+    }
+
+    @Test
+    fun `copyDrawing puts an image on the clipboard`() {
+        val testBitmap = createTestImageBitmap(20, 20, Color.Blue)
+        var clipboardHasImageBefore = false
         try {
-            realLogics.askForNotificationPermission()
-            // No assertion needed, just checking for no crash
+            val clipboard = Toolkit.getDefaultToolkit().systemClipboard
+            clipboardHasImageBefore = clipboard.isDataFlavorAvailable(DataFlavor.imageFlavor)
+            if (clipboardHasImageBefore) {
+                // Try to clear it for a cleaner test, though not guaranteed to work on all OS/setups
+                // A better approach is to just check *after* the operation.
+                // clipboard.setContents(StringSelection(""), null) // Clear with empty text
+            }
+            realLogics.copyDrawing(testBitmap)
+            assertTrue("Clipboard should contain image data after copyDrawing", clipboard.isDataFlavorAvailable(DataFlavor.imageFlavor))
+
+            // Optional: Try to retrieve and verify (can be flaky)
+            val transferable = clipboard.getContents(null)
+            assertNotNull("Transferable from clipboard should not be null", transferable)
+            val clipboardImage = transferable.getTransferData(DataFlavor.imageFlavor) as? java.awt.Image
+            assertNotNull("Image retrieved from clipboard should not be null", clipboardImage)
+
+            // Convert to BufferedImage to check dimensions
+            val bufferedImage = if (clipboardImage is BufferedImage) {
+                clipboardImage
+            } else {
+                val bImg = BufferedImage(clipboardImage!!.getWidth(null), clipboardImage.getHeight(null), BufferedImage.TYPE_INT_ARGB)
+                val g2d = bImg.createGraphics()
+                g2d.drawImage(clipboardImage, 0, 0, null)
+                g2d.dispose()
+                bImg
+            }
+            assertEquals("Width of clipboard image should match original", testBitmap.width, bufferedImage.width)
+            assertEquals("Height of clipboard image should match original", testBitmap.height, bufferedImage.height)
+
+        } catch (e: HeadlessException) {
+            System.err.println("Skipping clipboard test in headless environment: ${e.message}")
+            Assume.assumeNoException(e) // Skips test if in headless environment
         } catch (e: Exception) {
-            fail("askForNotificationPermission should execute without error: ${e.message}")
+            fail("copyDrawing or clipboard interaction failed: ${e.message}")
         }
     }
 
     @Test
-    fun `checkNotificationPermission calls onNotification lambda and returns false`() {
-        assertFalse(onNotificationCalled)
-        val result = realLogics.checkNotificationPermission()
-        assertTrue(onNotificationCalled)
-        assertFalse(result)
+    fun `copyDrawing with null ImageBitmap does not crash (graceful handling expected)`() {
+        // While the method expects a non-null ImageBitmap, testing how it handles
+        // unexpected null if it were to occur (e.g. due to an upstream error not caught).
+        // The current implementation of ImageBitmap.toAwtImage() would throw NPE.
+        // This test verifies that if such an error occurs, it's caught by the try-catch in copyDrawing.
+        try {
+            // We can't directly pass null due to non-nullable type,
+            // so this test is more about the robustness of the try-catch in the method itself.
+            // If the ImageBitmap.toAwtImage() part fails for any reason before clipboard interaction,
+            // the catch block in copyDrawing should handle it.
+            // For a direct test of null, you'd need to mock ImageBitmap or use platform-specific nulls.
+
+            // Simulating a scenario where toAwtImage() might fail, leading to an exception
+            // This is a bit contrived as ImageBitmap itself won't be null here.
+            val problematicBitmap = ImageBitmap(1, 1) // Valid bitmap
+            // If there was a way to make problematicBitmap.toAwtImage() throw, we'd test that.
+            // For now, we assume that any exception before clipboard.setContents is caught.
+            realLogics.copyDrawing(problematicBitmap) // Should not crash
+            println("copyDrawing with a (valid) bitmap did not crash, exception handling within the method is assumed to cover internal errors.")
+
+
+        } catch (e: Exception) {
+            fail("copyDrawing should gracefully handle internal errors, but an unexpected one occurred: ${e.message}")
+        }
     }
 }

--- a/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/RealLogicsTest.kt
+++ b/core/ui/src/jvmTest/kotlin/com/mshdabiola/ui/RealLogicsTest.kt
@@ -1,6 +1,7 @@
 /*
  * Designed and developed by 2024 mshdabiola (lawal abiola)
- * * Licensed under the Apache License, Version 2.0 (the "License");
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
@@ -74,7 +75,7 @@ class RealLogicsTest {
             // We test the imageSelectedCallback instead.
             savePhoto = { savePhotoCalled = true }, // For snapImage
             onNotification = { onNotificationCalled = true },
-            imageSelectedCallback = { path -> imageSelectedPath = path } // For chooseImage
+            imageSelectedCallback = { path -> imageSelectedPath = path }, // For chooseImage
         )
     }
 
@@ -107,7 +108,6 @@ class RealLogicsTest {
         realLogics.imageSelectedCallback(testPath)
         assertEquals(testPath, imageSelectedPath)
     }
-
 
     @Test
     fun `shareNote executes without error`() {
@@ -148,7 +148,10 @@ class RealLogicsTest {
                 // clipboard.setContents(StringSelection(""), null) // Clear with empty text
             }
             realLogics.copyDrawing(testBitmap)
-            assertTrue("Clipboard should contain image data after copyDrawing", clipboard.isDataFlavorAvailable(DataFlavor.imageFlavor))
+            assertTrue(
+                "Clipboard should contain image data after copyDrawing",
+                clipboard.isDataFlavorAvailable(DataFlavor.imageFlavor),
+            )
 
             // Optional: Try to retrieve and verify (can be flaky)
             val transferable = clipboard.getContents(null)
@@ -160,7 +163,12 @@ class RealLogicsTest {
             val bufferedImage = if (clipboardImage is BufferedImage) {
                 clipboardImage
             } else {
-                val bImg = BufferedImage(clipboardImage!!.getWidth(null), clipboardImage.getHeight(null), BufferedImage.TYPE_INT_ARGB)
+                val bImg =
+                    BufferedImage(
+                        clipboardImage!!.getWidth(null),
+                        clipboardImage.getHeight(null),
+                        BufferedImage.TYPE_INT_ARGB,
+                    )
                 val g2d = bImg.createGraphics()
                 g2d.drawImage(clipboardImage, 0, 0, null)
                 g2d.dispose()
@@ -168,7 +176,6 @@ class RealLogicsTest {
             }
             assertEquals("Width of clipboard image should match original", testBitmap.width, bufferedImage.width)
             assertEquals("Height of clipboard image should match original", testBitmap.height, bufferedImage.height)
-
         } catch (e: HeadlessException) {
             System.err.println("Skipping clipboard test in headless environment: ${e.message}")
             Assume.assumeNoException(e) // Skips test if in headless environment
@@ -196,9 +203,9 @@ class RealLogicsTest {
             // If there was a way to make problematicBitmap.toAwtImage() throw, we'd test that.
             // For now, we assume that any exception before clipboard.setContents is caught.
             realLogics.copyDrawing(problematicBitmap) // Should not crash
-            println("copyDrawing with a (valid) bitmap did not crash, exception handling within the method is assumed to cover internal errors.")
-
-
+            println(
+                "copyDrawing with a (valid) bitmap did not crash, exception handling within the method is assumed to cover internal errors.",
+            )
         } catch (e: Exception) {
             fail("copyDrawing should gracefully handle internal errors, but an unexpected one occurred: ${e.message}")
         }

--- a/core/ui/src/wasmJsMain/kotlin/com/mshdabiola/ui/RealLogics.kt
+++ b/core/ui/src/wasmJsMain/kotlin/com/mshdabiola/ui/RealLogics.kt
@@ -15,6 +15,7 @@
  */
 package com.mshdabiola.ui
 
+import androidx.compose.ui.graphics.ImageBitmap
 import com.mohamedrejeb.calf.picker.FilePickerLauncher
 import com.mshdabiola.model.note.NotePad
 import kotlinx.browser.window
@@ -65,5 +66,9 @@ class RealLogics(
     override fun checkNotificationPermission(): Boolean {
         onNotification()
         return false
+    }
+
+    override fun shareDrawing(bitmap: ImageBitmap) {
+
     }
 }

--- a/core/ui/src/wasmJsMain/kotlin/com/mshdabiola/ui/RealLogics.kt
+++ b/core/ui/src/wasmJsMain/kotlin/com/mshdabiola/ui/RealLogics.kt
@@ -20,7 +20,6 @@ import com.mohamedrejeb.calf.picker.FilePickerLauncher
 import com.mshdabiola.model.note.NotePad
 import kotlinx.browser.window
 
-// Top-level function for encoding URI components using JavaScript
 fun encodeURIComponentJs(str: String): JsString = js("encodeURIComponent(str)")
 
 class RealLogics(
@@ -33,16 +32,15 @@ class RealLogics(
         window.open(url, "_blank")
     }
 
+    @OptIn(ExperimentalWasmJsInterop::class)
     override fun openEmail(emailAddress: String, subject: String, body: String) {
-        // Simple mailto link for Wasm/JS.
-        // Encoding subject and body is important for special characters.
-        val encodedSubject = encodeURIComponentJs(subject) // Use the top-level function
-        val encodedBody = encodeURIComponentJs(body) // Use the top-level function
+        val encodedSubject = encodeURIComponentJs(subject)
+        val encodedBody = encodeURIComponentJs(body)
         window.open("mailto:$emailAddress?subject=$encodedSubject&body=$encodedBody", "_self")
     }
 
     override fun isVoiceAvailable(): Boolean {
-        return false
+        return false // Typically not available directly in browser Wasm without specific JS interop
     }
 
     override fun openVoice() {
@@ -50,7 +48,7 @@ class RealLogics(
     }
 
     override fun snapImage(path: String) {
-        savePhoto()
+        savePhoto() // Assumes this handles Wasm/JS specific saving if needed
     }
 
     override fun chooseImage() {
@@ -58,17 +56,30 @@ class RealLogics(
     }
 
     override fun shareNote(notePad: NotePad) {
+        // Web Share API could be used here if available and desired
+        println("ShareNote on Wasm: Title: ${notePad.title}, Detail: ${notePad.detail}")
+        // Example using Web Share API (check for navigator.share availability)
+        // if (js("typeof navigator.share") !== "undefined") { ... }
     }
 
     override fun askForNotificationPermission() {
+        // Browser Notification API
+        // js("Notification.requestPermission().then(function(permission) { console.log('Notification permission:', permission); });")
+        onNotification() // Call callback, actual permission handled by browser
     }
 
     override fun checkNotificationPermission(): Boolean {
         onNotification()
-        return false
+        // return js("Notification.permission === 'granted'") as Boolean
+        return false // Placeholder
     }
 
     override fun shareDrawing(bitmap: ImageBitmap) {
+        // For sharing, you might convert to data URL and use Web Share API
+        // or trigger a download.
+        println("shareDrawing on Wasm: (Implementation would be similar to copyDrawing then Web Share or download)")
+    }
 
+    override fun copyDrawing(bitmap: ImageBitmap) {
     }
 }

--- a/feature/detail/src/commonMain/kotlin/com/mshdabiola/detail/DetailViewModel.kt
+++ b/feature/detail/src/commonMain/kotlin/com/mshdabiola/detail/DetailViewModel.kt
@@ -99,15 +99,15 @@ class DetailViewModel(
                         isCheck = false,
                     )
                 }
-                checks.mapIndexed { index, item -> item.copy(id = index.toLong()) }
+                checks.mapIndexed { index, item -> item.copy(id = index.toLong()*-1) }
             } else {
                 emptyList()
             },
             images = detailArg.images.mapIndexed { index, string ->
-                NoteImage(id = index.toLong(), path = string, noteId = detailArg.id)
+                NoteImage(id = index.toLong()*-1, path = string, noteId = detailArg.id)
             },
             voices = detailArg.voices.mapIndexed { index, string ->
-                NoteVoice(id = index.toLong(), path = string, noteId = detailArg.id)
+                NoteVoice(id = index.toLong()*-1, path = string, noteId = detailArg.id)
             },
 
         ),

--- a/feature/detail/src/commonMain/kotlin/com/mshdabiola/detail/DetailViewModel.kt
+++ b/feature/detail/src/commonMain/kotlin/com/mshdabiola/detail/DetailViewModel.kt
@@ -99,15 +99,15 @@ class DetailViewModel(
                         isCheck = false,
                     )
                 }
-                checks.mapIndexed { index, item -> item.copy(id = index.toLong()*-1) }
+                checks.mapIndexed { index, item -> item.copy(id = index.toLong() * -1) }
             } else {
                 emptyList()
             },
             images = detailArg.images.mapIndexed { index, string ->
-                NoteImage(id = index.toLong()*-1, path = string, noteId = detailArg.id)
+                NoteImage(id = index.toLong() * -1, path = string, noteId = detailArg.id)
             },
             voices = detailArg.voices.mapIndexed { index, string ->
-                NoteVoice(id = index.toLong()*-1, path = string, noteId = detailArg.id)
+                NoteVoice(id = index.toLong() * -1, path = string, noteId = detailArg.id)
             },
 
         ),

--- a/feature/detail/src/jvmTest/kotlin/com/mshdabiola/detail/MoreOptionsSheetTest.kt
+++ b/feature/detail/src/jvmTest/kotlin/com/mshdabiola/detail/MoreOptionsSheetTest.kt
@@ -15,6 +15,7 @@
  */
 package com.mshdabiola.detail
 
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -60,6 +61,12 @@ class MoreOptionsSheetTest {
 
             override fun checkNotificationPermission(): Boolean {
                 return true
+            }
+            override fun shareDrawing(bitmap: ImageBitmap) {
+
+            }
+
+            override fun copyDrawing(bitmap: ImageBitmap) {
             }
         }
         composeTestRule.setContent {
@@ -114,6 +121,13 @@ class MoreOptionsSheetTest {
             override fun checkNotificationPermission(): Boolean {
                 return true
             }
+
+            override fun shareDrawing(bitmap: ImageBitmap) {
+
+            }
+
+            override fun copyDrawing(bitmap: ImageBitmap) {
+            }
         }
 
         composeTestRule.setContent {
@@ -163,6 +177,12 @@ class MoreOptionsSheetTest {
 
             override fun checkNotificationPermission(): Boolean {
                 return true
+            }
+            override fun shareDrawing(bitmap: ImageBitmap) {
+
+            }
+
+            override fun copyDrawing(bitmap: ImageBitmap) {
             }
         }
 
@@ -222,6 +242,12 @@ class MoreOptionsSheetTest {
 
             override fun checkNotificationPermission(): Boolean {
                 return true
+            }
+            override fun shareDrawing(bitmap: ImageBitmap) {
+
+            }
+
+            override fun copyDrawing(bitmap: ImageBitmap) {
             }
         }
 

--- a/feature/detail/src/jvmTest/kotlin/com/mshdabiola/detail/MoreOptionsSheetTest.kt
+++ b/feature/detail/src/jvmTest/kotlin/com/mshdabiola/detail/MoreOptionsSheetTest.kt
@@ -63,7 +63,6 @@ class MoreOptionsSheetTest {
                 return true
             }
             override fun shareDrawing(bitmap: ImageBitmap) {
-
             }
 
             override fun copyDrawing(bitmap: ImageBitmap) {
@@ -123,7 +122,6 @@ class MoreOptionsSheetTest {
             }
 
             override fun shareDrawing(bitmap: ImageBitmap) {
-
             }
 
             override fun copyDrawing(bitmap: ImageBitmap) {
@@ -179,7 +177,6 @@ class MoreOptionsSheetTest {
                 return true
             }
             override fun shareDrawing(bitmap: ImageBitmap) {
-
             }
 
             override fun copyDrawing(bitmap: ImageBitmap) {
@@ -244,7 +241,6 @@ class MoreOptionsSheetTest {
                 return true
             }
             override fun shareDrawing(bitmap: ImageBitmap) {
-
             }
 
             override fun copyDrawing(bitmap: ImageBitmap) {

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawScreen.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawScreen.kt
@@ -55,7 +55,7 @@ fun DrawScreen(
     onBack: () -> Unit = {},
     controller: DrawingController = remember { DrawingController() },
     drawUiState: DrawUiState = DrawUiState(),
-    onDeleteImage: () -> Unit = {},
+    onDeleteImage: (onComplete: (() -> Unit)?) -> Unit = {},
     onCopy: () -> Unit = {},
     onSend: () -> Unit = {},
 ) {
@@ -132,8 +132,8 @@ fun DrawScreen(
                                 text = { Text(text = stringResource(Res.string.modules_designsystem_delete)) },
                                 onClick = {
                                     showDropDown = false
-                                    onDeleteImage()
-                                    onBack()
+                                    onDeleteImage { onBack() }
+
                                 },
                                 modifier = Modifier.testTag(DrawScreenTestTags.DELETE_MENU_ITEM),
                             )

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawScreen.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawScreen.kt
@@ -133,7 +133,6 @@ fun DrawScreen(
                                 onClick = {
                                     showDropDown = false
                                     onDeleteImage { onBack() }
-
                                 },
                                 modifier = Modifier.testTag(DrawScreenTestTags.DELETE_MENU_ITEM),
                             )

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawScreen.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawScreen.kt
@@ -133,6 +133,7 @@ fun DrawScreen(
                                 onClick = {
                                     showDropDown = false
                                     onDeleteImage()
+                                    onBack()
                                 },
                                 modifier = Modifier.testTag(DrawScreenTestTags.DELETE_MENU_ITEM),
                             )

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawViewModel.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawViewModel.kt
@@ -41,7 +41,7 @@ class DrawViewModel(
     private val drawingRepository: NoteDrawingRepository,
     private val noteRepository: NoteRepository,
 
-) : ViewModel() {
+    ) : ViewModel() {
     private val detailArgs = MutableStateFlow(draw)
 
     val controller = DrawingController()
@@ -71,6 +71,7 @@ class DrawViewModel(
                     drawings = path,
                 )
             }
+
             !isInit && drawArg.id == null -> {
                 val noteId = if (detailArgs.value.noteId != null) {
                     detailArgs.value.noteId!!
@@ -95,6 +96,7 @@ class DrawViewModel(
                     drawings = emptyList(),
                 )
             }
+
             else -> {
                 drawingRepository.upsert(
                     NoteDrawing(
@@ -119,9 +121,11 @@ class DrawViewModel(
         initialValue = DrawUiState(),
     )
 
-    fun deleteDrawing() {
+    fun deleteDrawing(onComplete: (() -> Unit)? = null) {
+        val id = detailArgs.value.id ?: return
         viewModelScope.launch {
-            drawingRepository.delete(detailArgs.value.id!!)
+            drawingRepository.delete(id)
+            onComplete?.invoke()
         }
     }
 }

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawViewModel.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawViewModel.kt
@@ -41,7 +41,7 @@ class DrawViewModel(
     private val drawingRepository: NoteDrawingRepository,
     private val noteRepository: NoteRepository,
 
-    ) : ViewModel() {
+) : ViewModel() {
     private val detailArgs = MutableStateFlow(draw)
 
     val controller = DrawingController()

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawViewModel.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawViewModel.kt
@@ -119,10 +119,9 @@ class DrawViewModel(
         initialValue = DrawUiState(),
     )
 
-     fun deleteDrawing() {
+    fun deleteDrawing() {
         viewModelScope.launch {
             drawingRepository.delete(detailArgs.value.id!!)
         }
-
     }
 }

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawViewModel.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawViewModel.kt
@@ -119,41 +119,6 @@ class DrawViewModel(
         initialValue = DrawUiState(),
     )
 
-//    fun saveImage2(paths: ImmutablePath): Deferred<String?> {
-//        return viewModelScope.async {
-//            try {
-//                val pathsMap = changeToDrawPath(paths)
-//
-//                // deleteByNoteId exist drawing from db
-//                drawingPathRepository.deleteByNoteId(imageID)
-//                if (pathsMap.isEmpty()) {
-//                    // deleteByNoteId image too
-//                    File(contentManager.getImagePath(imageID)).deleteOnExit()
-//                    null
-//                } else {
-//                    val width = drawingArgs.width
-//                    val height = drawingArgs.height
-//                    val density = drawingArgs.density
-//
-//                    val bitmap = getBitMap(
-//                        changeToPathAndData(paths),
-//                        width,
-//                        height,
-//                        density,
-//                    )
-//                    val path = contentManager.getImagePath(imageID)
-//                    contentManager.saveBitmap(path, bitmap)
-//
-//                    drawingPathRepository.insert(pathsMap)
-//                    path
-//                }
-//            } catch (e: Exception) {
-//                e.printStackTrace()
-//                null
-//            }
-//        }
-//    }
-
      fun deleteDrawing() {
         viewModelScope.launch {
             drawingRepository.delete(detailArgs.value.id!!)

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawViewModel.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/DrawViewModel.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 @OptIn(FlowPreview::class)
 class DrawViewModel(
@@ -153,7 +154,10 @@ class DrawViewModel(
 //        }
 //    }
 
-    suspend fun deleteDrawing() {
-        drawingRepository.delete(detailArgs.value.id!!)
+     fun deleteDrawing() {
+        viewModelScope.launch {
+            drawingRepository.delete(detailArgs.value.id!!)
+        }
+
     }
 }

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
@@ -62,25 +62,11 @@ fun NavGraphBuilder.drawScreen(
             val imageBitmap = ImageBitmap(1000, 1000)
             val imageBitmap2 = drawPathsOnImage(imageBitmap, state.value.drawings, density)
             logics.shareDrawing(imageBitmap2)
-
-//            val file = File(state.value.filePath!!)
-//            val uri = FileProvider.getUriForFile(context, context.packageName + ".provider", file)
-//            val intent = ShareCompat.IntentBuilder(context)
-//                .setType("image/*")
-//                .setStream(uri)
-//                .setChooserTitle("NotePad")
-//                .createChooserIntent()
-//
-//            context.startActivity(intent)
         }
         val onCopy = {
-//            val file = File(state.value.filePath!!)
-//            val uri = FileProvider.getUriForFile(context, context.packageName + ".provider", file)
-//
-//            val content = context.contentResolver
-//            val clip = ClipData.newUri(content, "image", uri)
-//            val c = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-//            c.setPrimaryClip(clip)
+            val imageBitmap = ImageBitmap(1000, 1000)
+            val imageBitmap2 = drawPathsOnImage(imageBitmap, state.value.drawings, density)
+            logics.copyDrawing(imageBitmap2)
         }
 
         DrawScreen(

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
@@ -83,7 +83,7 @@ fun NavGraphBuilder.drawScreen(
             },
             onCopy = onCopy,
             onSend = onSend,
-            onDeleteImage = {},
+            onDeleteImage =viewModel::deleteDrawing,
         )
     }
 }

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
@@ -41,7 +41,7 @@ fun NavGraphBuilder.drawScreen(
     modifier: Modifier = Modifier,
     onBack: (Long?) -> Unit,
 
-    ) {
+) {
     composable<Draw> { backStack ->
 
         val draw: Draw = backStack.toRoute()
@@ -83,7 +83,7 @@ fun NavGraphBuilder.drawScreen(
             },
             onCopy = onCopy,
             onSend = onSend,
-            onDeleteImage =viewModel::deleteDrawing,
+            onDeleteImage = viewModel::deleteDrawing,
         )
     }
 }

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
@@ -16,7 +16,6 @@
 package com.mshdabiola.draw.navigation
 
 import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.ImageBitmap
@@ -31,9 +30,6 @@ import com.mshdabiola.draw.DrawViewModel
 import com.mshdabiola.ui.drawPathsOnImage
 import com.mshdabiola.ui.getPlatformLogics
 import com.mshdabiola.ui.path
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.parameter.parameterSetOf

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
@@ -59,7 +59,7 @@ fun NavGraphBuilder.drawScreen(
         val density = LocalDensity.current
 
         val onSend = {
-            val imageBitmap = ImageBitmap(200, 200)
+            val imageBitmap = ImageBitmap(1000, 1000)
             val imageBitmap2 = drawPathsOnImage(imageBitmap, state.value.drawings, density)
             logics.shareDrawing(imageBitmap2)
 

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
@@ -16,7 +16,9 @@
 package com.mshdabiola.draw.navigation
 
 import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.platform.LocalDensity
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -28,9 +30,15 @@ import com.mshdabiola.draw.DrawScreen
 import com.mshdabiola.draw.DrawViewModel
 import com.mshdabiola.ui.drawPathsOnImage
 import com.mshdabiola.ui.getPlatformLogics
+import com.mshdabiola.ui.path
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.parameter.parameterSetOf
+import kotlin.math.max
+import kotlin.math.min
 
 fun NavController.navigateToDraw(detail: Draw) {
     navigate(detail)
@@ -59,14 +67,54 @@ fun NavGraphBuilder.drawScreen(
         val density = LocalDensity.current
 
         val onSend = {
-            val imageBitmap = ImageBitmap(1000, 1000)
-            val imageBitmap2 = drawPathsOnImage(imageBitmap, state.value.drawings, density)
-            logics.shareDrawing(imageBitmap2)
+            val paths = state.value.drawings
+            if (paths.isNotEmpty()) {
+                // 1. Calculate bounds from all paths
+                val bounds = paths.map { it.path.getBounds() }
+                    .reduce { acc, rect ->
+                        Rect(
+                            left = min(acc.left, rect.left),
+                            top = min(acc.top, rect.top),
+                            right = max(acc.right, rect.right),
+                            bottom = max(acc.bottom, rect.bottom),
+                        )
+                    }
+
+                // 2. Determine target size while preserving aspect ratio
+                val aspectRatio = bounds.width / bounds.height.coerceAtLeast(1f)
+                val targetWidth = 1080f
+                val targetHeight = targetWidth / aspectRatio
+
+                // 3. Create bitmap and draw
+                val imageBitmap = ImageBitmap(targetWidth.toInt(), targetHeight.toInt())
+                val finalBitmap = drawPathsOnImage(imageBitmap, paths, density)
+                logics.shareDrawing(finalBitmap)
+            }
         }
         val onCopy = {
-            val imageBitmap = ImageBitmap(1000, 1000)
-            val imageBitmap2 = drawPathsOnImage(imageBitmap, state.value.drawings, density)
-            logics.copyDrawing(imageBitmap2)
+            val paths = state.value.drawings
+            if (paths.isNotEmpty()) {
+                // 1. Calculate bounds from all paths
+                val bounds = paths.map { it.path.getBounds() }
+                    .reduce { acc, rect ->
+                        Rect(
+                            left = min(acc.left, rect.left),
+                            top = min(acc.top, rect.top),
+                            right = max(acc.right, rect.right),
+                            bottom = max(acc.bottom, rect.bottom),
+                        )
+                    }
+
+                // 2. Determine target size while preserving aspect ratio
+                val aspectRatio = bounds.width / bounds.height.coerceAtLeast(1f)
+                val targetWidth = 1080f
+                val targetHeight = targetWidth / aspectRatio
+
+                // 3. Create bitmap and draw
+                val imageBitmap = ImageBitmap(targetWidth.toInt(), targetHeight.toInt())
+                val finalBitmap = drawPathsOnImage(imageBitmap, paths, density)
+                logics.copyDrawing(finalBitmap)
+            }
         }
 
         DrawScreen(

--- a/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
+++ b/feature/draw/src/commonMain/kotlin/com/mshdabiola/draw/navigation/DrawNavigation.kt
@@ -17,6 +17,8 @@ package com.mshdabiola.draw.navigation
 
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.platform.LocalDensity
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -24,6 +26,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.mshdabiola.draw.DrawScreen
 import com.mshdabiola.draw.DrawViewModel
+import com.mshdabiola.ui.drawPathsOnImage
+import com.mshdabiola.ui.getPlatformLogics
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.parameter.parameterSetOf
@@ -37,7 +41,7 @@ fun NavGraphBuilder.drawScreen(
     modifier: Modifier = Modifier,
     onBack: (Long?) -> Unit,
 
-) {
+    ) {
     composable<Draw> { backStack ->
 
         val draw: Draw = backStack.toRoute()
@@ -51,8 +55,14 @@ fun NavGraphBuilder.drawScreen(
                 },
             )
         val state = viewModel.drawingState.collectAsStateWithLifecycle()
+        val logics = getPlatformLogics()
+        val density = LocalDensity.current
 
         val onSend = {
+            val imageBitmap = ImageBitmap(200, 200)
+            val imageBitmap2 = drawPathsOnImage(imageBitmap, state.value.drawings, density)
+            logics.shareDrawing(imageBitmap2)
+
 //            val file = File(state.value.filePath!!)
 //            val uri = FileProvider.getUriForFile(context, context.packageName + ".provider", file)
 //            val intent = ShareCompat.IntentBuilder(context)

--- a/feature/draw/src/jvmTest/kotlin/com/mshdabiola/draw/DrawViewModelTest.kt
+++ b/feature/draw/src/jvmTest/kotlin/com/mshdabiola/draw/DrawViewModelTest.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -226,10 +227,68 @@ class DrawViewModelTest {
         assertEquals("Drawing should exist before delete", 1, drawingRepository.getAll().first().size)
 
         viewModel.deleteDrawing() // This is a suspend function
+        advanceUntilIdle() // Ensure delete coroutine completes
 
         assertEquals("Drawing should be deleted from repository", 0, drawingRepository.getAll().first().size)
         // Note: This test doesn't assert drawingState changes post-delete, as the current
         // ViewModel logic might not re-emit based on repository deletion in a way that this flow captures directly.
         // If drawingState *should* reflect the deletion (e.g. by becoming null or empty), further assertions on the flow would be needed.
+    }
+
+    @Test
+    fun `multiplePathChanges_withinDebounce_areSavedTogether`() = runTest {
+        noteRepository.upsert(NotePad(id = testNewDrawingWithNoteIdArgs.noteId!!)) // Ensure note exists
+        initializeViewModel(testNewDrawingWithNoteIdArgs)
+
+        viewModel.drawingState.test {
+            advanceTimeBy(600) // Allow initial save and get drawingId
+            val initialState = expectMostRecentItem()
+            val drawingId = initialState.drawingId
+            assertNotNull("Drawing ID should be set after initial save", drawingId)
+            assertTrue("Initial state drawings should be empty", initialState.drawings.isEmpty())
+
+            val path1 = Path(points = mutableListOf(Point(10f, 10f)))
+            val path2 = Path(points = mutableListOf(Point(20f, 20f)))
+            val path3 = Path(points = mutableListOf(Point(30f, 30f)))
+
+            // Add paths rapidly
+            Snapshot.withMutableSnapshot {
+                viewModel.controller.drawingPaths.add(path1)
+            }
+            advanceTimeBy(200) // Less than debounce (500ms)
+
+            Snapshot.withMutableSnapshot {
+                viewModel.controller.drawingPaths.add(path2)
+            }
+            advanceTimeBy(200) // Still within debounce window from first change, and from second
+
+            Snapshot.withMutableSnapshot {
+                viewModel.controller.drawingPaths.add(path3)
+            }
+            // ViewModel's snapshotFlow for controller.drawingPaths should have emitted on each add.
+            // We need to consume these if they trigger DrawUiState emissions directly (before save)
+            // Skip these intermediate emissions if they occur to focus on the final saved state.
+            // Depending on how combine/stateIn is set up, there might be emissions here.
+            // For this test, we are interested in the final state after the debounce & save.
+
+            advanceTimeBy(600) // Ensure enough time for debounce after the LAST change
+            advanceUntilIdle()   // Ensure all coroutines complete
+
+            val finalState = expectMostRecentItem() // Get the state after debounce and save
+
+            assertEquals("Final state should have 3 paths", 3, finalState.drawings.size)
+            assertTrue("Final state should contain path1", finalState.drawings.any { it.points == path1.points })
+            assertTrue("Final state should contain path2", finalState.drawings.any { it.points == path2.points })
+            assertTrue("Final state should contain path3", finalState.drawings.any { it.points == path3.points })
+
+            val savedDrawing = drawingRepository.get(drawingId!!).first()
+            assertNotNull("Saved drawing should exist in repository", savedDrawing)
+            assertEquals("Saved drawing in repository should have 3 paths", 3, savedDrawing!!.paths.size)
+            assertTrue("Saved drawing should contain path1", savedDrawing.paths.any { it.points == path1.points })
+            assertTrue("Saved drawing should contain path2", savedDrawing.paths.any { it.points == path2.points })
+            assertTrue("Saved drawing should contain path3", savedDrawing.paths.any { it.points == path3.points })
+
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }

--- a/feature/draw/src/jvmTest/kotlin/com/mshdabiola/draw/DrawViewModelTest.kt
+++ b/feature/draw/src/jvmTest/kotlin/com/mshdabiola/draw/DrawViewModelTest.kt
@@ -272,7 +272,7 @@ class DrawViewModelTest {
             // For this test, we are interested in the final state after the debounce & save.
 
             advanceTimeBy(600) // Ensure enough time for debounce after the LAST change
-            advanceUntilIdle()   // Ensure all coroutines complete
+            advanceUntilIdle() // Ensure all coroutines complete
 
             val finalState = expectMostRecentItem() // Get the state after debounce and save
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Share and copy drawings to other apps or clipboard (Android, Desktop, Web stubs).
  - Resizable, rotatable selection rectangle with draggable handles.
  - Generate/export images from drawings.

- UI Improvements
  - Drawing tabs switched to SynTabRow with centered layout.
  - Refined color/width selectors, expanded/reordered color palette, new default pen color.
  - Custom Undo/Redo icons.

- Behavior Changes
  - Deleting a drawing triggers navigation after deletion.
  - ID/nullification logic adjusted affecting initial item IDs and which IDs become null.

- Tests
  - New/updated tests for drawing export, clipboard, and debounce/save behavior.

- Chores
  - Android cache path added for shared images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->